### PR TITLE
Add computeCOM method to AnimationProperties for centre of mass computation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ CMakeUserPresets.json
 build/
 .vscode
 vcpkg_installed
+coverage
+*.log
+scripts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,3 +35,7 @@ add_subdirectory(${PROJECT_SOURCE_DIR}/src/rendering)
 add_subdirectory(${PROJECT_SOURCE_DIR}/src/shared)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE sharedLib animationLib modelingLib renderingLib)
+
+if (BUILD_TESTS)
+    add_subdirectory(${PROJECT_SOURCE_DIR}/test)
+endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -5,7 +5,8 @@
       "name": "vcpkg",
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "BUILD_TESTS": "ON"
       }
     }
   ]

--- a/include/animation/AnimationProperties.hpp
+++ b/include/animation/AnimationProperties.hpp
@@ -15,6 +15,16 @@ namespace animation {
  * Stores all animation related properties of an object
 */
 class AnimationProperties {
+private:
+    Eigen::Vector3d com;
+    double volume;
+
+    /**
+     * Computes the center of mass and volume for the given vertices and indices
+     * and stores them in the class members
+     */
+    void computeCenreOfMassAndVolume(const std::vector<Eigen::Vector3d> &vertices, const std::vector<unsigned int> &indices);
+
 public:
     AnimationProperties(const modeling::ModelProperties &modelProps);
     ~AnimationProperties();

--- a/include/animation/AnimationProperties.hpp
+++ b/include/animation/AnimationProperties.hpp
@@ -19,13 +19,18 @@ private:
     Eigen::Vector3d com;
     double volume;
 
+public:
     /**
      * Computes the center of mass and volume for the given vertices and indices
-     * and stores them in the class members
+     * and stores them in the provided parameters.
      */
-    void computeCenreOfMassAndVolume(const std::vector<Eigen::Vector3d> &vertices, const std::vector<unsigned int> &indices);
+    static void computeCenreOfMassAndVolume(
+        const std::vector<Eigen::Vector3d> &vertices, 
+        const std::vector<unsigned int> &indices, 
+        Eigen::Vector3d &com, 
+        double &volume
+    );
 
-public:
     AnimationProperties(const modeling::ModelProperties &modelProps);
     ~AnimationProperties();
 

--- a/src/animation/AnimationProperties.cpp
+++ b/src/animation/AnimationProperties.cpp
@@ -2,6 +2,14 @@
 
 using namespace animation;
 
+// Private methods
+
+void AnimationProperties::computeCenreOfMassAndVolume(const std::vector<Eigen::Vector3d> &vertices, const std::vector<unsigned int> &indices) {
+    // TODO
+}
+
+// Public methods
+
 AnimationProperties::AnimationProperties(const modeling::ModelProperties &modelProps) {
 
 }
@@ -37,5 +45,5 @@ void AnimationProperties::update(double timestep) {
  * A model matrix places the object in the correct point in world space
 */
 Eigen::Affine3d getModelMatrix() {
-
+    return Eigen::Affine3d::Identity();
 }

--- a/src/animation/AnimationProperties.cpp
+++ b/src/animation/AnimationProperties.cpp
@@ -5,7 +5,19 @@ using namespace animation;
 // Private methods
 
 void AnimationProperties::computeCenreOfMassAndVolume(const std::vector<Eigen::Vector3d> &vertices, const std::vector<unsigned int> &indices) {
-    // TODO
+    auto comX24Xvolume = Eigen::Vector3d(0,0,0);
+    double volumeX6 = 0;
+    for(auto indices_iter = indices.begin(); indices_iter != indices.end(); indices_iter += 3) {
+        Eigen::Matrix3d A;
+        A.col(0) = vertices[indices_iter[0]];
+        A.col(1) = vertices[indices_iter[1]];
+        A.col(2) = vertices[indices_iter[2]];
+        double curVolumeX6 = A.determinant();
+        comX24Xvolume += curVolumeX6 * (A.col(0) + A.col(1) + A.col(2));
+        volumeX6 += curVolumeX6;
+    }
+    this->com = comX24Xvolume / (4.0 * volumeX6);
+    this->volume = std::abs(volumeX6 / 6.0);
 }
 
 // Public methods

--- a/src/animation/AnimationProperties.cpp
+++ b/src/animation/AnimationProperties.cpp
@@ -2,25 +2,28 @@
 
 using namespace animation;
 
-// Private methods
-
-void AnimationProperties::computeCenreOfMassAndVolume(const std::vector<Eigen::Vector3d> &vertices, const std::vector<unsigned int> &indices) {
+void AnimationProperties::computeCenreOfMassAndVolume(
+    const std::vector<Eigen::Vector3d> &vertices, 
+    const std::vector<unsigned int> &indices,
+    Eigen::Vector3d &com, 
+    double &volume
+) {
     auto comX24Xvolume = Eigen::Vector3d(0,0,0);
     double volumeX6 = 0;
     for(auto indices_iter = indices.begin(); indices_iter != indices.end(); indices_iter += 3) {
+        // A = column matrix [v0 v1 v2]
         Eigen::Matrix3d A;
         A.col(0) = vertices[indices_iter[0]];
         A.col(1) = vertices[indices_iter[1]];
         A.col(2) = vertices[indices_iter[2]];
+
         double curVolumeX6 = A.determinant();
         comX24Xvolume += curVolumeX6 * (A.col(0) + A.col(1) + A.col(2));
         volumeX6 += curVolumeX6;
     }
-    this->com = comX24Xvolume / (4.0 * volumeX6);
-    this->volume = std::abs(volumeX6 / 6.0);
+    com = comX24Xvolume / (4.0 * volumeX6);
+    volume = std::abs(volumeX6 / 6.0);
 }
-
-// Public methods
 
 AnimationProperties::AnimationProperties(const modeling::ModelProperties &modelProps) {
 

--- a/src/animation/AnimationProperties.cpp
+++ b/src/animation/AnimationProperties.cpp
@@ -21,7 +21,7 @@ void AnimationProperties::computeCenreOfMassAndVolume(
         comX24Xvolume += curVolumeX6 * (A.col(0) + A.col(1) + A.col(2));
         volumeX6 += curVolumeX6;
     }
-    com = comX24Xvolume / (4.0 * volumeX6);
+    com = comX24Xvolume / (volumeX6 ? 4.0 * volumeX6 : 1.0);
     volume = std::abs(volumeX6 / 6.0);
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,28 @@
+enable_testing()
+
+find_package(GTest REQUIRED)
+include(GoogleTest)
+
+file(GLOB TEST_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/**/*_test.cpp")
+
+add_executable(unit_tests ${TEST_FILES})
+
+target_link_libraries(unit_tests PRIVATE sharedLib animationLib modelingLib renderingLib)
+
+target_include_directories(unit_tests
+  PRIVATE
+    "${CMAKE_SOURCE_DIR}/include"
+)
+
+target_link_libraries(unit_tests PRIVATE GTest::gtest GTest::gtest_main)
+
+find_package(glad CONFIG REQUIRED)
+target_link_libraries(${PROJECT_NAME} PRIVATE glad::glad)
+
+find_package(glfw3 CONFIG REQUIRED)
+target_link_libraries(${PROJECT_NAME} PRIVATE glfw)
+
+find_package(Eigen3 CONFIG REQUIRED NO_MODULE)
+target_link_libraries(${PROJECT_NAME} PRIVATE Eigen3::Eigen)
+
+gtest_discover_tests(unit_tests)

--- a/test/animation/AnimationProperties_test.cpp
+++ b/test/animation/AnimationProperties_test.cpp
@@ -1,0 +1,43 @@
+#include <gtest/gtest.h>
+
+#include "animation/AnimationProperties.hpp"
+#include "modeling/ModelProperties.hpp"
+
+using namespace animation;
+
+TEST(AnimationPropertiesTest, ComputeCentreOfMassAndVolumeEmptyMesh) {
+    std::vector<Eigen::Vector3d> vertices;
+    std::vector<unsigned int> indices;
+    Eigen::Vector3d com;
+    double volume;
+
+    AnimationProperties::computeCenreOfMassAndVolume(vertices, indices, com, volume);
+
+    EXPECT_EQ(com, Eigen::Vector3d(0, 0, 0));
+    EXPECT_EQ(volume, 0);
+}
+
+TEST(AnimationPropertiesTest, ComputeCenterOfMassAndVolumeOfTetrahedron) {
+    std::vector<Eigen::Vector3d> vertices = {
+        Eigen::Vector3d(0, 0, 0),
+        Eigen::Vector3d(1, 0, 0),
+        Eigen::Vector3d(0, 1, 0),
+        Eigen::Vector3d(0, 0, 1)
+    };
+    std::vector<unsigned int> indices = {
+        0, 1, 2,
+        0, 1, 3,
+        0, 2, 3,
+        1, 2, 3
+    };
+
+    Eigen::Vector3d expectedCom(0.25, 0.25, 0.25), actualCom;
+    double expectedVolume = 1.0 / 6.0, actualVolume;
+
+    AnimationProperties::computeCenreOfMassAndVolume(vertices, indices, actualCom, actualVolume);
+
+    EXPECT_NEAR(actualCom.x(), expectedCom.x(), 1e-6);
+    EXPECT_NEAR(actualCom.y(), expectedCom.y(), 1e-6);
+    EXPECT_NEAR(actualCom.z(), expectedCom.z(), 1e-6);
+    EXPECT_NEAR(actualVolume, expectedVolume, 1e-6);
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,11 +1,12 @@
 {
   "dependencies": [
+    "eigen3",
     "glad",
     "glfw3",
     "glm",
     "opengl",
     "opengl-registry",
     "stb",
-    "eigen3"
+    "gtest"
   ]
 }


### PR DESCRIPTION
PR for issue #3 

Used this for algorithm reference: https://www.melax.com/volint.html

Coverage not looking too good at first glance, however, looking inside the file, we see that the function that was implemented is fully covered:
<img width="1726" height="308" alt="image" src="https://github.com/user-attachments/assets/4519a72f-5d34-469a-8c6f-90333e372f14" />
<img width="784" height="886" alt="image" src="https://github.com/user-attachments/assets/f8ae1ae9-0d89-4bf2-ae62-7fe6fbd4b69f" />
