### PR TITLE
Basic draft for material class

### DIFF
--- a/include/modeling/material.hpp
+++ b/include/modeling/material.hpp
@@ -1,0 +1,123 @@
+#pragma once
+#include <glm/glm.hpp>
+#include <assimp/scene.h>
+#include "assimp/material.h"
+
+// A Material 
+struct Material {
+    // name of the material
+    const std::string name;
+
+    // how reflective the material is
+    // 0.0 = smooth 
+    // 1.0 = rough
+    const float roughness;      
+
+    // how metallic the surface is
+    // 0.0 = dielectric
+    // 1.0 = metal
+    const float metallic;       
+
+    // how transparent the material is
+    // 0.0 = opaque
+    // 1.0 = transparent
+    const float opacity;        
+    
+    // Uniform general illumination
+    const glm::vec4 ambient;    
+    
+    // Color and brightness from light source
+    const glm::vec4 diffuse;    
+
+    // Shiny bight lights from reflections
+    const glm::vec4 specular;   
+
+    // Emitting color and light
+    const glm::vec4 emissive;   
+    
+    Material(
+        std::string name,
+        float roughness,
+        float metallic,
+        float opacity,
+        glm::vec4 ambient,
+        glm::vec4 diffuse,
+        glm::vec4 specular,
+        glm::vec4 emissive
+    ):
+        name(std::move(name)),
+        roughness(roughness),
+        metallic(metallic),
+        opacity(opacity),
+        ambient(ambient),
+        emissive(emissive),
+        diffuse(diffuse),
+        specular(specular)
+    {
+        // validation
+        assert(0.0 <= roughness && roughness <= 1.0 && "roughness must be within [0.0, 1.0]");
+        assert(0.0 <= metallic  && metallic  <= 1.0 && "metallic must be within [0.0, 1.0]");
+        assert(0.0 <= opacity   && opacity   <= 1.0 && "opacity must be within [0.0, 1.0]");
+    };
+    ~Material() = default;
+
+    // constructs a `Material` from an imported aiMaterial
+    static Material from_aiMaterial(aiMaterial *material);
+
+private:
+    // prevent copies
+    Material(const Material&) = delete;
+    Material& operator=(const Material&) = delete;
+
+    // prevent moving
+    Material(Material&&) = delete;
+    Material& operator=(Material&&) = delete;
+
+};
+
+// A unique index into `MaterialManager` 
+// to retrieve a `Material` 
+struct MaterialHandle {
+public:
+    friend class MaterialManager;
+
+    // creates a `MaterialHandle` without checking if its valid
+    static MaterialHandle new_unchecked(size_t id);
+
+private:
+    size_t id;
+    MaterialHandle(size_t id): id(id) {}
+};
+
+// A Context managing all imported `Material`s
+// that exist within a scene
+class MaterialManager {
+public:
+
+    // constructor from an imported scene
+    MaterialManager() = default;
+    ~MaterialManager() = default;
+
+    // prevent copies
+    MaterialManager(const MaterialManager&) = delete;
+    MaterialManager& operator=(const MaterialManager&) = delete;
+    
+    // allow moves
+    MaterialManager(MaterialManager&&) = default;
+    MaterialManager& operator=(MaterialManager&&) = default;
+
+    // constructor from a scene
+    static MaterialManager from_aiScene(aiScene scene);
+
+    // returns a material from its unique handle
+    const Material& get(MaterialHandle handle) const noexcept;
+
+    // returns a reference to a material given its name
+    // throws std::out_of_range the material is not found.
+    const Material& find(std::string name) const;
+
+
+private:
+    // list of all materials in a scene 
+    std::vector<Material> materials;
+};

--- a/include/modeling/material.hpp
+++ b/include/modeling/material.hpp
@@ -2,63 +2,80 @@
 #include <glm/glm.hpp>
 #include <assimp/scene.h>
 #include "assimp/material.h"
+struct Texture {
+    const std::unique_ptr<const uint8_t> data;
+    const uint32_t width;
+    const uint32_t height;
+    const uint32_t n_channels;
+    const uint32_t id;
+
+    Texture(
+        std::unique_ptr<const uint8_t> data,
+        uint32_t width,
+        uint32_t height,
+        uint32_t n_channels,
+        uint32_t id
+    ): 
+        data(std::move(data)),
+        width(width),
+        height(height),
+        n_channels(n_channels),
+        id(id) {}
+
+    Texture() = delete;
+    ~Texture() = default;
+    
+private:
+    // no copy
+    Texture(const Texture&) = delete;
+    Texture& operator=(const Texture&) = delete;
+    
+    // no move
+    Texture(Texture&&) = delete;
+    Texture& operator=(Texture&&) = delete;
+};
 
 // A Material 
 struct Material {
     // name of the material
     const std::string name;
 
-    // how reflective the material is
-    // 0.0 = smooth 
-    // 1.0 = rough
-    const float roughness;      
+    // aiTextureType_BASE_COLOR
+    const Texture &base_color;
 
-    // how metallic the surface is
-    // 0.0 = dielectric
-    // 1.0 = metal
-    const float metallic;       
+    // aiTextureType_NORMAL_CAMERA
+    const Texture &normal_camera;
 
-    // how transparent the material is
-    // 0.0 = opaque
-    // 1.0 = transparent
-    const float opacity;        
+    // aiTextureType_EMISSION_COLOR
+    const Texture &emission_color;
+
+    // aiTextureType_METALNESS
+    const Texture &metalness;
+
+    // aiTextureType_DIFFUSE_ROUGHNESS
+    const Texture &diffuse_roughness;
+
+    // aiTextureType_AMBIENT_OCCLUSION
+    const Texture &ambient_occlusion;
     
-    // Uniform general illumination
-    const glm::vec4 ambient;    
-    
-    // Color and brightness from light source
-    const glm::vec4 diffuse;    
-
-    // Shiny bight lights from reflections
-    const glm::vec4 specular;   
-
-    // Emitting color and light
-    const glm::vec4 emissive;   
     
     Material(
         std::string name,
-        float roughness,
-        float metallic,
-        float opacity,
-        glm::vec4 ambient,
-        glm::vec4 diffuse,
-        glm::vec4 specular,
-        glm::vec4 emissive
+        Texture &base_color,
+        Texture &normal_camera,
+        Texture &emission_color,
+        Texture &metalness,
+        Texture &diffuse_roughness,
+        Texture &ambient_occlusion
     ):
         name(std::move(name)),
-        roughness(roughness),
-        metallic(metallic),
-        opacity(opacity),
-        ambient(ambient),
-        emissive(emissive),
-        diffuse(diffuse),
-        specular(specular)
-    {
-        // validation
-        assert(0.0 <= roughness && roughness <= 1.0 && "roughness must be within [0.0, 1.0]");
-        assert(0.0 <= metallic  && metallic  <= 1.0 && "metallic must be within [0.0, 1.0]");
-        assert(0.0 <= opacity   && opacity   <= 1.0 && "opacity must be within [0.0, 1.0]");
-    };
+        base_color(base_color),
+        normal_camera(normal_camera),
+        emission_color(emission_color),
+        metalness(metalness),
+        diffuse_roughness(diffuse_roughness),
+        ambient_occlusion(ambient_occlusion)
+    {};
     ~Material() = default;
 
     // constructs a `Material` from an imported aiMaterial
@@ -95,7 +112,7 @@ class MaterialManager {
 public:
 
     // constructor from an imported scene
-    MaterialManager() = default;
+    explicit MaterialManager(aiScene *scene);
     ~MaterialManager() = default;
 
     // prevent copies
@@ -120,4 +137,7 @@ public:
 private:
     // list of all materials in a scene 
     std::vector<Material> materials;
+
+    // list of all textures in a scene
+    std::vector<Texture> textures;
 };

--- a/include/modeling/material.hpp
+++ b/include/modeling/material.hpp
@@ -2,6 +2,7 @@
 #include <glm/glm.hpp>
 #include <assimp/scene.h>
 #include "assimp/material.h"
+#include <memory>
 struct Texture {
     const std::unique_ptr<const uint8_t> data;
     const uint32_t width;

--- a/include/modeling/material.hpp
+++ b/include/modeling/material.hpp
@@ -3,6 +3,7 @@
 #include <assimp/scene.h>
 #include "assimp/material.h"
 #include <memory>
+#include <vector>
 struct Texture {
     const std::unique_ptr<const uint8_t> data;
     const uint32_t width;

--- a/src/modeling/material.cpp
+++ b/src/modeling/material.cpp
@@ -1,0 +1,95 @@
+#include "material.hpp" 
+#include <iostream> 
+
+Material Material::from_aiMaterial(aiMaterial *material) {
+    std::string name = std::string(material->GetName().C_Str());
+    
+    float roughness;
+    if (material->Get(AI_MATKEY_ROUGHNESS_FACTOR, roughness) != aiReturn::aiReturn_SUCCESS) {
+        std::cerr << "failed to get roughness" << std::endl;
+    }
+
+    float metallic;
+    if (material->Get(AI_MATKEY_METALLIC_FACTOR, metallic) != aiReturn::aiReturn_SUCCESS) {
+        std::cerr << "failed to get metallic" << std::endl;
+    }
+
+    float opacity;
+    if (material->Get(AI_MATKEY_OPACITY, opacity) != aiReturn::aiReturn_SUCCESS) {
+        std::cerr << "failed to get opacity" << std::endl;
+    }
+
+    aiColor4D ambient_tmp;
+    if (material->Get(AI_MATKEY_COLOR_AMBIENT, ambient_tmp) != aiReturn::aiReturn_SUCCESS) {
+        std::cerr << "failed to get ambient" << std::endl;
+    }
+    glm::vec4 ambient(ambient_tmp.r, ambient_tmp.g, ambient_tmp.b, ambient_tmp.a);
+    
+    aiColor4D diffuse_tmp;
+    if (material->Get(AI_MATKEY_COLOR_DIFFUSE, diffuse_tmp) != aiReturn::aiReturn_SUCCESS) {
+        std::cerr << "failed to get diffuse" << std::endl;
+    }
+    glm::vec4 diffuse(diffuse_tmp.r, diffuse_tmp.g, diffuse_tmp.b, diffuse_tmp.a);
+    
+
+    aiColor4D specular_tmp;
+    if (material->Get(AI_MATKEY_COLOR_SPECULAR, specular_tmp) != aiReturn::aiReturn_SUCCESS) {
+        std::cerr << "failed to get specular" << std::endl;
+    }
+    glm::vec4 specular(specular_tmp.r, specular_tmp.g, specular_tmp.b, specular_tmp.a);
+
+    
+    aiColor4D emissive_tmp;
+    if (material->Get(AI_MATKEY_COLOR_EMISSIVE, emissive_tmp) != aiReturn::aiReturn_SUCCESS) {
+        std::cerr << "failed to get emissive" << std::endl;
+    }
+    glm::vec4 emissive(emissive_tmp.r, emissive_tmp.g, emissive_tmp.b, emissive_tmp.a);
+    
+    return Material {
+        name,      
+        roughness, 
+        metallic,  
+        opacity,   
+        ambient,   
+        diffuse,   
+        specular,  
+        emissive   
+    };
+}
+
+MaterialManager MaterialManager::from_aiScene(aiScene scene) {
+    std::unordered_set<std::string> seen;
+
+    MaterialManager manager;
+    manager.materials.reserve(scene.mNumMaterials);
+    for (size_t i = 0; i < scene.mNumMaterials; i++) {
+        auto material = Material::from_aiMaterial(scene.mMaterials[i]);
+        if (seen.find(material.name) != seen.end()) {
+            std::cerr << "duplicate name found: " << material.name << " (ignoring)" << std::endl;
+        } else {
+            seen.insert(material.name);
+        }
+        manager.materials.emplace_back(material);
+    }
+    return manager;
+}
+
+MaterialHandle MaterialHandle::new_unchecked(size_t id) {
+    return MaterialHandle{ id };
+}
+
+const Material& MaterialManager::get(MaterialHandle handle) const noexcept {
+    this->materials[handle.id];
+}
+
+const Material& MaterialManager::find(std::string name) const {
+    for (auto it = this->materials.begin(); it != this->materials.end(); ++it) {
+        if (it->name == name) {
+            return *it;
+        }
+    }
+    throw std::out_of_range(name + " is not a registered material");
+}
+
+
+

--- a/src/modeling/material.cpp
+++ b/src/modeling/material.cpp
@@ -2,76 +2,13 @@
 #include <iostream> 
 
 Material Material::from_aiMaterial(aiMaterial *material) {
-    std::string name = std::string(material->GetName().C_Str());
-    
-    float roughness;
-    if (material->Get(AI_MATKEY_ROUGHNESS_FACTOR, roughness) != aiReturn::aiReturn_SUCCESS) {
-        std::cerr << "failed to get roughness" << std::endl;
-    }
-
-    float metallic;
-    if (material->Get(AI_MATKEY_METALLIC_FACTOR, metallic) != aiReturn::aiReturn_SUCCESS) {
-        std::cerr << "failed to get metallic" << std::endl;
-    }
-
-    float opacity;
-    if (material->Get(AI_MATKEY_OPACITY, opacity) != aiReturn::aiReturn_SUCCESS) {
-        std::cerr << "failed to get opacity" << std::endl;
-    }
-
-    aiColor4D ambient_tmp;
-    if (material->Get(AI_MATKEY_COLOR_AMBIENT, ambient_tmp) != aiReturn::aiReturn_SUCCESS) {
-        std::cerr << "failed to get ambient" << std::endl;
-    }
-    glm::vec4 ambient(ambient_tmp.r, ambient_tmp.g, ambient_tmp.b, ambient_tmp.a);
-    
-    aiColor4D diffuse_tmp;
-    if (material->Get(AI_MATKEY_COLOR_DIFFUSE, diffuse_tmp) != aiReturn::aiReturn_SUCCESS) {
-        std::cerr << "failed to get diffuse" << std::endl;
-    }
-    glm::vec4 diffuse(diffuse_tmp.r, diffuse_tmp.g, diffuse_tmp.b, diffuse_tmp.a);
-    
-
-    aiColor4D specular_tmp;
-    if (material->Get(AI_MATKEY_COLOR_SPECULAR, specular_tmp) != aiReturn::aiReturn_SUCCESS) {
-        std::cerr << "failed to get specular" << std::endl;
-    }
-    glm::vec4 specular(specular_tmp.r, specular_tmp.g, specular_tmp.b, specular_tmp.a);
-
-    
-    aiColor4D emissive_tmp;
-    if (material->Get(AI_MATKEY_COLOR_EMISSIVE, emissive_tmp) != aiReturn::aiReturn_SUCCESS) {
-        std::cerr << "failed to get emissive" << std::endl;
-    }
-    glm::vec4 emissive(emissive_tmp.r, emissive_tmp.g, emissive_tmp.b, emissive_tmp.a);
-    
-    return Material {
-        name,      
-        roughness, 
-        metallic,  
-        opacity,   
-        ambient,   
-        diffuse,   
-        specular,  
-        emissive   
-    };
+    throw std::runtime_error("todo for model loading");
 }
 
-MaterialManager MaterialManager::from_aiScene(aiScene scene) {
-    std::unordered_set<std::string> seen;
-
-    MaterialManager manager;
-    manager.materials.reserve(scene.mNumMaterials);
-    for (size_t i = 0; i < scene.mNumMaterials; i++) {
-        auto material = Material::from_aiMaterial(scene.mMaterials[i]);
-        if (seen.find(material.name) != seen.end()) {
-            std::cerr << "duplicate name found: " << material.name << " (ignoring)" << std::endl;
-        } else {
-            seen.insert(material.name);
-        }
-        manager.materials.emplace_back(material);
-    }
-    return manager;
+MaterialManager::MaterialManager(aiScene *scene) {
+    // load all textures first into this.textures
+    // load materials which then reference the loaded textures
+    throw std::runtime_error("todo for model loading");
 }
 
 MaterialHandle MaterialHandle::new_unchecked(size_t id) {
@@ -90,6 +27,3 @@ const Material& MaterialManager::find(std::string name) const {
     }
     throw std::out_of_range(name + " is not a registered material");
 }
-
-
-

--- a/src/modeling/material.cpp
+++ b/src/modeling/material.cpp
@@ -16,7 +16,7 @@ MaterialHandle MaterialHandle::new_unchecked(size_t id) {
 }
 
 const Material& MaterialManager::get(MaterialHandle handle) const noexcept {
-    this->materials[handle.id];
+    return this->materials[handle.id];
 }
 
 const Material& MaterialManager::find(std::string name) const {

--- a/src/modeling/material.cpp
+++ b/src/modeling/material.cpp
@@ -1,4 +1,4 @@
-#include "material.hpp" 
+#include "modeling/material.hpp" 
 #include <iostream> 
 
 Material Material::from_aiMaterial(aiMaterial *material) {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,11 +1,12 @@
 {
   "dependencies": [
+    "eigen3",
     "glad",
     "glfw3",
     "glm",
     "opengl",
     "opengl-registry",
     "stb",
-    "eigen3"
+    "assimp"
   ]
 }


### PR DESCRIPTION
# Overview 
The `Material` is a simple struct containing relevant fields used for PBR. 

The `MaterialManager` holds all the `Material` and as such the lifetimes of `Material` are tied to this structure rather than being self managed.

The `MaterialHandle` is a unique handle for `MaterialManager` to retrieve a `Material`. 


# Usecase
The asset management system will own a `MaterialManager` 
Models will own a `MaterialHandle` 
`MaterialHandle`  should only be created using `MaterialHandle::new_unchecked`  during models loading otherwise be careful.
`Material`'s attributes will be access directly instead of using getters.

# Questions
- Any missing/useless fields in the `Material` struct? 
- Should the `from_aiScene` and `from_aiMaterial` associated  functions be moved elsewhere? (ie. to what ever handles loading everything)
- The names convention is currently very literal. Any suggested naming conventions?
- Is there a need to search a material by name? 
- Any other useful methods/functions relating to materials?
- replace `MaterialHandle` with just an `int`? 

## notes
I am not a c++ dev and the code is probably not the most c++ style. suggestions are welcomed
