### PR TITLE
Make libraries static

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ build.sh
 .idea/
 .cmake/
 test_coverage.sh
+coverage*
+*.log

--- a/include/shared/Object.hpp
+++ b/include/shared/Object.hpp
@@ -2,10 +2,7 @@
 #define OBJECT_HPP
 
 #include <string>
-
-#ifdef __linux__
-    #include <memory>
-#endif
+#include <memory>
 
 #include "animation/AnimationProperties.hpp"
 #include "modeling/ModelProperties.hpp"

--- a/src/animation/CMakeLists.txt
+++ b/src/animation/CMakeLists.txt
@@ -1,6 +1,6 @@
 file(GLOB ANIMATION_SRC_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_LIST_DIR}/*.cpp")
 
-add_library(animationLib SHARED ${ANIMATION_SRC_FILES})
+add_library(animationLib STATIC ${ANIMATION_SRC_FILES})
 
 target_include_directories(animationLib PRIVATE
   ${PROJECT_SOURCE_DIR}/include

--- a/src/modeling/CMakeLists.txt
+++ b/src/modeling/CMakeLists.txt
@@ -1,6 +1,6 @@
 file(GLOB MODELING_SRC_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_LIST_DIR}/*.cpp")
 
-add_library(modelingLib SHARED ${MODELING_SRC_FILES})
+add_library(modelingLib STATIC ${MODELING_SRC_FILES})
 
 target_include_directories(modelingLib PRIVATE
   ${PROJECT_SOURCE_DIR}/include

--- a/src/rendering/CMakeLists.txt
+++ b/src/rendering/CMakeLists.txt
@@ -1,6 +1,6 @@
 file(GLOB RENDERING_SRC_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_LIST_DIR}/*.cpp")
 
-add_library(renderingLib SHARED ${RENDERING_SRC_FILES})
+add_library(renderingLib STATIC ${RENDERING_SRC_FILES})
 
 target_include_directories(renderingLib PRIVATE
   ${PROJECT_SOURCE_DIR}/include

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -1,6 +1,6 @@
 file(GLOB SHARED_SRC_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_LIST_DIR}/*.cpp")
 
-add_library(sharedLib SHARED ${SHARED_SRC_FILES})
+add_library(sharedLib STATIC ${SHARED_SRC_FILES})
 
 target_include_directories(sharedLib PRIVATE
   ${PROJECT_SOURCE_DIR}/include


### PR DESCRIPTION
This should fix the build error occuring on Windows systems where the linker was having trouble dealing with some of our circular dependencies