### PR TITLE
drag and slide abstraction

### DIFF
--- a/include/app/ui/components/DragFloat.hpp
+++ b/include/app/ui/components/DragFloat.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <app/ui/ImGuiComponent.hpp>
+#include <imgui.h>
+#include <functional>
+#include <string>
+#include <array>
+
+namespace sauce::ui {
+
+template<int N = 1>
+class DragFloat : public ImGuiComponent {
+    static_assert(N >= 1 && N <= 4, "DragFloat component count must be between 1 and 4");
+
+public:
+    using Callback = std::function<void(std::array<float, N>&)>;
+
+    DragFloat(const std::string& name, const std::string& label, std::array<float, N>& value,
+              float speed = 1.0f, float min = 0.0f, float max = 0.0f,
+              const std::string& format = "%.3f", Callback onChanged = nullptr)
+        : ImGuiComponent(name), label(label), value(value), speed(speed), min(min), max(max),
+          format(format), onChanged(onChanged) {}
+
+    void render() override {
+        if (!enabled) return;
+
+        bool changed = false;
+
+        if constexpr (N == 1) {
+            changed = ImGui::DragFloat(label.c_str(), value.data(), speed, min, max, format.c_str());
+        } else if constexpr (N == 2) {
+            changed = ImGui::DragFloat2(label.c_str(), value.data(), speed, min, max, format.c_str());
+        } else if constexpr (N == 3) {
+            changed = ImGui::DragFloat3(label.c_str(), value.data(), speed, min, max, format.c_str());
+        } else if constexpr (N == 4) {
+            changed = ImGui::DragFloat4(label.c_str(), value.data(), speed, min, max, format.c_str());
+        }
+
+        if (changed && onChanged) {
+            onChanged(value);
+        }
+    }
+
+    void setSpeed(float spd) { speed = spd; }
+    void setRange(float newMin, float newMax) { min = newMin; max = newMax; }
+    void setFormat(const std::string& fmt) { format = fmt; }
+
+protected:
+    std::string label;
+    std::array<float, N>& value;
+    float speed;
+    float min;
+    float max;
+    std::string format;
+    Callback onChanged;
+};
+
+}

--- a/include/app/ui/components/DragInt.hpp
+++ b/include/app/ui/components/DragInt.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <app/ui/ImGuiComponent.hpp>
+#include <imgui.h>
+#include <functional>
+#include <string>
+#include <array>
+
+namespace sauce::ui {
+
+template<int N = 1>
+class DragInt : public ImGuiComponent {
+    static_assert(N >= 1 && N <= 4, "DragInt component count must be between 1 and 4");
+
+public:
+    using Callback = std::function<void(std::array<int, N>&)>;
+
+    DragInt(const std::string& name, const std::string& label, std::array<int, N>& value,
+            float speed = 1.0f, int min = 0, int max = 0,
+            const std::string& format = "%d", Callback onChanged = nullptr)
+        : ImGuiComponent(name), label(label), value(value), speed(speed), min(min), max(max),
+          format(format), onChanged(onChanged) {}
+
+    void render() override {
+        if (!enabled) return;
+
+        bool changed = false;
+
+        if constexpr (N == 1) {
+            changed = ImGui::DragInt(label.c_str(), value.data(), speed, min, max, format.c_str());
+        } else if constexpr (N == 2) {
+            changed = ImGui::DragInt2(label.c_str(), value.data(), speed, min, max, format.c_str());
+        } else if constexpr (N == 3) {
+            changed = ImGui::DragInt3(label.c_str(), value.data(), speed, min, max, format.c_str());
+        } else if constexpr (N == 4) {
+            changed = ImGui::DragInt4(label.c_str(), value.data(), speed, min, max, format.c_str());
+        }
+
+        if (changed && onChanged) {
+            onChanged(value);
+        }
+    }
+
+    void setSpeed(float spd) { speed = spd; }
+    void setRange(int newMin, int newMax) { min = newMin; max = newMax; }
+    void setFormat(const std::string& fmt) { format = fmt; }
+
+protected:
+    std::string label;
+    std::array<int, N>& value;
+    float speed;
+    int min;
+    int max;
+    std::string format;
+    Callback onChanged;
+};
+
+}

--- a/include/app/ui/components/SliderAngle.hpp
+++ b/include/app/ui/components/SliderAngle.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <app/ui/ImGuiComponent.hpp>
+#include <imgui.h>
+#include <functional>
+#include <string>
+
+namespace sauce::ui {
+
+class SliderAngle : public ImGuiComponent {
+public:
+    using Callback = std::function<void(float)>;
+
+    SliderAngle(const std::string& name, const std::string& label, float* valueRadians,
+                float minDegrees = -360.0f, float maxDegrees = 360.0f,
+                const std::string& format = "%.0f deg", Callback onChanged = nullptr);
+
+    void render() override;
+
+    void setRange(float minDegrees, float maxDegrees) { 
+        this->minDegrees = minDegrees; 
+        this->maxDegrees = maxDegrees; 
+    }
+    void setFormat(const std::string& fmt) { format = fmt; }
+
+private:
+    std::string label;
+    float* valueRadians;
+    float minDegrees;
+    float maxDegrees;
+    std::string format;
+    Callback onChanged;
+};
+
+}

--- a/include/app/ui/components/SliderFloat.hpp
+++ b/include/app/ui/components/SliderFloat.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <app/ui/ImGuiComponent.hpp>
+#include <imgui.h>
+#include <functional>
+#include <string>
+#include <array>
+
+namespace sauce::ui {
+
+template<int N = 1>
+class SliderFloat : public ImGuiComponent {
+    static_assert(N >= 1 && N <= 4, "SliderFloat component count must be between 1 and 4");
+
+public:
+    using Callback = std::function<void(std::array<float, N>&)>;
+
+    SliderFloat(const std::string& name, const std::string& label, std::array<float, N>& value,
+                float min = 0.0f, float max = 1.0f,
+                const std::string& format = "%.3f", Callback onChanged = nullptr)
+        : ImGuiComponent(name), label(label), value(value), min(min), max(max),
+          format(format), onChanged(onChanged) {}
+
+    void render() override {
+        if (!enabled) return;
+
+        bool changed = false;
+
+        if constexpr (N == 1) {
+            changed = ImGui::SliderFloat(label.c_str(), value.data(), min, max, format.c_str());
+        } else if constexpr (N == 2) {
+            changed = ImGui::SliderFloat2(label.c_str(), value.data(), min, max, format.c_str());
+        } else if constexpr (N == 3) {
+            changed = ImGui::SliderFloat3(label.c_str(), value.data(), min, max, format.c_str());
+        } else if constexpr (N == 4) {
+            changed = ImGui::SliderFloat4(label.c_str(), value.data(), min, max, format.c_str());
+        }
+
+        if (changed && onChanged) {
+            onChanged(value);
+        }
+    }
+
+    void setRange(float newMin, float newMax) { min = newMin; max = newMax; }
+    void setFormat(const std::string& fmt) { format = fmt; }
+
+protected:
+    std::string label;
+    std::array<float, N>& value;
+    float min;
+    float max;
+    std::string format;
+    Callback onChanged;
+};
+
+}

--- a/include/app/ui/components/SliderInt.hpp
+++ b/include/app/ui/components/SliderInt.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <app/ui/ImGuiComponent.hpp>
+#include <imgui.h>
+#include <functional>
+#include <string>
+#include <array>
+
+namespace sauce::ui {
+
+template<int N = 1>
+class SliderInt : public ImGuiComponent {
+    static_assert(N >= 1 && N <= 4, "SliderInt component count must be between 1 and 4");
+
+public:
+    using Callback = std::function<void(std::array<int, N>&)>;
+
+    SliderInt(const std::string& name, const std::string& label, std::array<int, N>& value,
+              int min = 0, int max = 100,
+              const std::string& format = "%d", Callback onChanged = nullptr)
+        : ImGuiComponent(name), label(label), value(value), min(min), max(max),
+          format(format), onChanged(onChanged) {}
+
+    void render() override {
+        if (!enabled) return;
+
+        bool changed = false;
+
+        if constexpr (N == 1) {
+            changed = ImGui::SliderInt(label.c_str(), value.data(), min, max, format.c_str());
+        } else if constexpr (N == 2) {
+            changed = ImGui::SliderInt2(label.c_str(), value.data(), min, max, format.c_str());
+        } else if constexpr (N == 3) {
+            changed = ImGui::SliderInt3(label.c_str(), value.data(), min, max, format.c_str());
+        } else if constexpr (N == 4) {
+            changed = ImGui::SliderInt4(label.c_str(), value.data(), min, max, format.c_str());
+        }
+
+        if (changed && onChanged) {
+            onChanged(value);
+        }
+    }
+
+    void setRange(int newMin, int newMax) { min = newMin; max = newMax; }
+    void setFormat(const std::string& fmt) { format = fmt; }
+
+protected:
+    std::string label;
+    std::array<int, N>& value;
+    int min;
+    int max;
+    std::string format;
+    Callback onChanged;
+};
+
+}

--- a/src/app/ui/SliderAngle.cpp
+++ b/src/app/ui/SliderAngle.cpp
@@ -1,0 +1,22 @@
+#include <app/ui/components/SliderAngle.hpp>
+#include <string>
+
+namespace sauce::ui {
+
+SliderAngle::SliderAngle(const std::string& name, const std::string& label, float* valueRadians,
+                         float minDegrees, float maxDegrees,
+                         const std::string& format, Callback onChanged)
+    : ImGuiComponent(name), label(label), valueRadians(valueRadians),
+      minDegrees(minDegrees), maxDegrees(maxDegrees), format(format), onChanged(onChanged) {}
+
+void SliderAngle::render() {
+    if (!enabled) return;
+
+    if (ImGui::SliderAngle(label.c_str(), valueRadians, minDegrees, maxDegrees, format.c_str())) {
+        if (onChanged) {
+            onChanged(*valueRadians);
+        }
+    }
+}
+
+}


### PR DESCRIPTION
CLOSES #153 

ok, i kinda deviated from what the other PRs are doing (cpp + hpp).. its better practice but we lose codebase consistency WDYT

i think the overall implementation is good though

bad way:
```cpp
float position[2] = {1.0f, 2.0f};
auto slider = std::make_shared<SliderFloat3>("Pos", position); 

// Result: doom and despair
void render() {
    ImGui::SliderFloat3(label, data); // no way to check if 'data' has 3 elements
}
```

template implementation city:
```cpp
std::array<float, 2> position = {1.0f, 2.0f};

// Result: compilation error
auto slider = std::make_shared<SliderFloat<3>>("Pos", position); 
```


demo pics (code not included)
<img width="2558" height="1486" alt="sliders2" src="https://github.com/user-attachments/assets/18831b97-e353-4f2e-a664-adc61e76dd9a" />

