### PR TITLE
152 abstract UI components

### DIFF
--- a/include/app/ui/components/ChildWindow.hpp
+++ b/include/app/ui/components/ChildWindow.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <app/ui/ImGuiComponent.hpp>
+#include <imgui.h>
+#include <functional>
+#include <string>
+
+namespace sauce::ui {
+
+/**
+ * ChildWindow - Wraps ImGui::BeginChild() / ImGui::EndChild()
+ * Creates a scrollable region within a parent window
+ */
+class ChildWindow : public ImGuiComponent {
+public:
+    using ContentCallback = std::function<void()>;
+
+    ChildWindow(const std::string& name, const ImVec2& size = ImVec2(0, 0), 
+                ImGuiChildFlags childFlags = 0, ImGuiWindowFlags windowFlags = 0,
+                ContentCallback content = nullptr);
+
+    void render() override;
+
+    void setSize(const ImVec2& newSize) { size = newSize; }
+    ImVec2 getSize() const { return size; }
+    
+    void setContent(ContentCallback newContent) { content = newContent; }
+    void setChildFlags(ImGuiChildFlags newFlags) { childFlags = newFlags; }
+    void setWindowFlags(ImGuiWindowFlags newFlags) { windowFlags = newFlags; }
+
+private:
+    ImVec2 size;
+    ImGuiChildFlags childFlags;
+    ImGuiWindowFlags windowFlags;
+    ContentCallback content;
+};
+
+}

--- a/include/app/ui/components/CollapsingHeader.hpp
+++ b/include/app/ui/components/CollapsingHeader.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <app/ui/ImGuiComponent.hpp>
+#include <imgui.h>
+#include <functional>
+#include <string>
+
+namespace sauce::ui {
+
+/**
+ * CollapsingHeader - Wraps ImGui::CollapsingHeader()
+ * Creates a collapsible section header
+ */
+class CollapsingHeader : public ImGuiComponent {
+public:
+    using ContentCallback = std::function<void()>;
+
+    CollapsingHeader(const std::string& name, const std::string& label, 
+                     ContentCallback content = nullptr, ImGuiTreeNodeFlags flags = 0);
+
+    void render() override;
+
+    void setLabel(const std::string& newLabel) { label = newLabel; }
+    const std::string& getLabel() const { return label; }
+    
+    void setContent(ContentCallback newContent) { content = newContent; }
+    void setFlags(ImGuiTreeNodeFlags newFlags) { flags = newFlags; }
+    
+    bool isHeaderOpen() const { return headerOpen; }
+    
+    // Optional: track visibility with close button
+    bool* getVisiblePtr() { return &visible; }
+    bool isVisible() const { return visible; }
+    void setVisible(bool vis) { visible = vis; }
+
+private:
+    std::string label;
+    ContentCallback content;
+    ImGuiTreeNodeFlags flags;
+    bool headerOpen = false;
+    bool visible = true;
+};
+
+}

--- a/include/app/ui/components/Columns.hpp
+++ b/include/app/ui/components/Columns.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <app/ui/ImGuiComponent.hpp>
+#include <imgui.h>
+#include <functional>
+#include <string>
+
+namespace sauce::ui {
+
+/**
+ * Columns - Wraps ImGui::Columns() / ImGui::BeginColumns() / ImGui::EndColumns()
+ * Creates a multi-column layout
+ */
+class Columns : public ImGuiComponent {
+public:
+    using ContentCallback = std::function<void()>;
+
+    Columns(const std::string& name, int count = 1, const std::string& id = "", 
+            bool border = true, ContentCallback content = nullptr);
+
+    void render() override;
+
+    void setCount(int newCount) { count = newCount; }
+    int getCount() const { return count; }
+    
+    void setId(const std::string& newId) { id = newId; }
+    const std::string& getId() const { return id; }
+    
+    void setBorder(bool newBorder) { border = newBorder; }
+    bool hasBorder() const { return border; }
+    
+    void setContent(ContentCallback newContent) { content = newContent; }
+
+    // Static helper to advance to next column
+    static void nextColumn() { ImGui::NextColumn(); }
+
+private:
+    int count;
+    std::string id;
+    bool border;
+    ContentCallback content;
+};
+
+}

--- a/include/app/ui/components/Group.hpp
+++ b/include/app/ui/components/Group.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <app/ui/ImGuiComponent.hpp>
+#include <imgui.h>
+#include <functional>
+#include <string>
+
+namespace sauce::ui {
+
+/**
+ * Group - Wraps ImGui::BeginGroup() / ImGui::EndGroup()
+ * Groups widgets together (useful for alignment, drag and drop, etc.)
+ */
+class Group : public ImGuiComponent {
+public:
+    using ContentCallback = std::function<void()>;
+
+    Group(const std::string& name, ContentCallback content = nullptr);
+
+    void render() override;
+
+    void setContent(ContentCallback newContent) { content = newContent; }
+
+private:
+    ContentCallback content;
+};
+
+}

--- a/include/app/ui/components/SameLine.hpp
+++ b/include/app/ui/components/SameLine.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <app/ui/ImGuiComponent.hpp>
+#include <imgui.h>
+#include <string>
+
+namespace sauce::ui {
+
+/**
+ * SameLine - Wraps ImGui::SameLine()
+ * Places the next element on the same line (horizontal layout)
+ */
+class SameLine : public ImGuiComponent {
+public:
+    explicit SameLine(const std::string& name, float offsetFromStartX = 0.0f, float spacing = -1.0f);
+
+    void render() override;
+
+    void setOffsetFromStartX(float offset) { offsetFromStartX = offset; }
+    float getOffsetFromStartX() const { return offsetFromStartX; }
+    
+    void setSpacing(float newSpacing) { spacing = newSpacing; }
+    float getSpacing() const { return spacing; }
+
+private:
+    float offsetFromStartX;
+    float spacing;
+};
+
+}

--- a/include/app/ui/components/Separator.hpp
+++ b/include/app/ui/components/Separator.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <app/ui/ImGuiComponent.hpp>
+#include <imgui.h>
+#include <string>
+
+namespace sauce::ui {
+
+/**
+ * Separator - Wraps ImGui::Separator()
+ * Creates a horizontal line separator
+ */
+class Separator : public ImGuiComponent {
+public:
+    explicit Separator(const std::string& name);
+
+    void render() override;
+};
+
+}

--- a/include/app/ui/components/Spacing.hpp
+++ b/include/app/ui/components/Spacing.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <app/ui/ImGuiComponent.hpp>
+#include <imgui.h>
+#include <string>
+
+namespace sauce::ui {
+
+/**
+ * Spacing - Wraps ImGui::Spacing()
+ * Adds vertical spacing between elements
+ */
+class Spacing : public ImGuiComponent {
+public:
+    explicit Spacing(const std::string& name, int count = 1);
+
+    void render() override;
+
+    void setCount(int newCount) { count = newCount; }
+    int getCount() const { return count; }
+
+private:
+    int count;  // Number of spacing calls to make
+};
+
+}

--- a/include/app/ui/components/TreeNode.hpp
+++ b/include/app/ui/components/TreeNode.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <app/ui/ImGuiComponent.hpp>
+#include <imgui.h>
+#include <functional>
+#include <string>
+
+namespace sauce::ui {
+
+/**
+ * TreeNode - Wraps ImGui::TreeNode() / ImGui::TreePop()
+ * Creates a collapsible tree hierarchy element
+ */
+class TreeNode : public ImGuiComponent {
+public:
+    using ContentCallback = std::function<void()>;
+
+    TreeNode(const std::string& name, const std::string& label, 
+             ContentCallback content = nullptr, ImGuiTreeNodeFlags flags = 0);
+
+    void render() override;
+
+    void setLabel(const std::string& newLabel) { label = newLabel; }
+    const std::string& getLabel() const { return label; }
+    
+    void setContent(ContentCallback newContent) { content = newContent; }
+    void setFlags(ImGuiTreeNodeFlags newFlags) { flags = newFlags; }
+    
+    bool isNodeOpen() const { return nodeOpen; }
+
+private:
+    std::string label;
+    ContentCallback content;
+    ImGuiTreeNodeFlags flags;
+    bool nodeOpen = false;
+};
+
+}

--- a/include/app/ui/components/Window.hpp
+++ b/include/app/ui/components/Window.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <app/ui/ImGuiComponent.hpp>
+#include <imgui.h>
+#include <functional>
+#include <string>
+
+namespace sauce::ui {
+
+/**
+ * Window - Wraps ImGui::Begin() / ImGui::End()
+ * Creates a window container that can hold other UI elements
+ */
+class Window : public ImGuiComponent {
+public:
+    using ContentCallback = std::function<void()>;
+
+    Window(const std::string& name, const std::string& title, ContentCallback content = nullptr, 
+           ImGuiWindowFlags flags = 0);
+
+    void render() override;
+
+    void setTitle(const std::string& newTitle) { title = newTitle; }
+    const std::string& getTitle() const { return title; }
+    
+    void setContent(ContentCallback newContent) { content = newContent; }
+    void setFlags(ImGuiWindowFlags newFlags) { flags = newFlags; }
+    
+    bool* getOpenPtr() { return &isOpen; }
+    bool isWindowOpen() const { return isOpen; }
+    void setOpen(bool open) { isOpen = open; }
+
+private:
+    std::string title;
+    ContentCallback content;
+    ImGuiWindowFlags flags;
+    bool isOpen = true;
+};
+
+}

--- a/src/app/ui/ChildWindow.cpp
+++ b/src/app/ui/ChildWindow.cpp
@@ -1,0 +1,22 @@
+#include <app/ui/components/ChildWindow.hpp>
+
+namespace sauce::ui {
+
+ChildWindow::ChildWindow(const std::string& name, const ImVec2& size, 
+                         ImGuiChildFlags childFlags, ImGuiWindowFlags windowFlags,
+                         ContentCallback content)
+    : ImGuiComponent(name), size(size), childFlags(childFlags), 
+      windowFlags(windowFlags), content(content) {}
+
+void ChildWindow::render() {
+    if (!enabled) return;
+    
+    if (ImGui::BeginChild(name.c_str(), size, childFlags, windowFlags)) {
+        if (content) {
+            content();
+        }
+    }
+    ImGui::EndChild();
+}
+
+}

--- a/src/app/ui/CollapsingHeader.cpp
+++ b/src/app/ui/CollapsingHeader.cpp
@@ -1,0 +1,20 @@
+#include <app/ui/components/CollapsingHeader.hpp>
+
+namespace sauce::ui {
+
+CollapsingHeader::CollapsingHeader(const std::string& name, const std::string& label, 
+                                   ContentCallback content, ImGuiTreeNodeFlags flags)
+    : ImGuiComponent(name), label(label), content(content), flags(flags) {}
+
+void CollapsingHeader::render() {
+    if (!enabled || !visible) return;
+    
+    headerOpen = ImGui::CollapsingHeader(label.c_str(), flags);
+    if (headerOpen) {
+        if (content) {
+            content();
+        }
+    }
+}
+
+}

--- a/src/app/ui/Columns.cpp
+++ b/src/app/ui/Columns.cpp
@@ -1,0 +1,23 @@
+#include <app/ui/components/Columns.hpp>
+
+namespace sauce::ui {
+
+Columns::Columns(const std::string& name, int count, const std::string& id, 
+                 bool border, ContentCallback content)
+    : ImGuiComponent(name), count(count), id(id), border(border), content(content) {}
+
+void Columns::render() {
+    if (!enabled) return;
+    
+    // Use the legacy Columns API for simplicity
+    ImGui::Columns(count, id.empty() ? nullptr : id.c_str(), border);
+    
+    if (content) {
+        content();
+    }
+    
+    // Reset to single column
+    ImGui::Columns(1);
+}
+
+}

--- a/src/app/ui/Group.cpp
+++ b/src/app/ui/Group.cpp
@@ -1,0 +1,18 @@
+#include <app/ui/components/Group.hpp>
+
+namespace sauce::ui {
+
+Group::Group(const std::string& name, ContentCallback content)
+    : ImGuiComponent(name), content(content) {}
+
+void Group::render() {
+    if (!enabled) return;
+    
+    ImGui::BeginGroup();
+    if (content) {
+        content();
+    }
+    ImGui::EndGroup();
+}
+
+}

--- a/src/app/ui/SameLine.cpp
+++ b/src/app/ui/SameLine.cpp
@@ -1,0 +1,14 @@
+#include <app/ui/components/SameLine.hpp>
+
+namespace sauce::ui {
+
+SameLine::SameLine(const std::string& name, float offsetFromStartX, float spacing)
+    : ImGuiComponent(name), offsetFromStartX(offsetFromStartX), spacing(spacing) {}
+
+void SameLine::render() {
+    if (!enabled) return;
+    
+    ImGui::SameLine(offsetFromStartX, spacing);
+}
+
+}

--- a/src/app/ui/Separator.cpp
+++ b/src/app/ui/Separator.cpp
@@ -1,0 +1,14 @@
+#include <app/ui/components/Separator.hpp>
+
+namespace sauce::ui {
+
+Separator::Separator(const std::string& name)
+    : ImGuiComponent(name) {}
+
+void Separator::render() {
+    if (!enabled) return;
+    
+    ImGui::Separator();
+}
+
+}

--- a/src/app/ui/Spacing.cpp
+++ b/src/app/ui/Spacing.cpp
@@ -1,0 +1,16 @@
+#include <app/ui/components/Spacing.hpp>
+
+namespace sauce::ui {
+
+Spacing::Spacing(const std::string& name, int count)
+    : ImGuiComponent(name), count(count) {}
+
+void Spacing::render() {
+    if (!enabled) return;
+    
+    for (int i = 0; i < count; ++i) {
+        ImGui::Spacing();
+    }
+}
+
+}

--- a/src/app/ui/TreeNode.cpp
+++ b/src/app/ui/TreeNode.cpp
@@ -1,0 +1,21 @@
+#include <app/ui/components/TreeNode.hpp>
+
+namespace sauce::ui {
+
+TreeNode::TreeNode(const std::string& name, const std::string& label, 
+                   ContentCallback content, ImGuiTreeNodeFlags flags)
+    : ImGuiComponent(name), label(label), content(content), flags(flags) {}
+
+void TreeNode::render() {
+    if (!enabled) return;
+    
+    nodeOpen = ImGui::TreeNodeEx(label.c_str(), flags);
+    if (nodeOpen) {
+        if (content) {
+            content();
+        }
+        ImGui::TreePop();
+    }
+}
+
+}

--- a/src/app/ui/Window.cpp
+++ b/src/app/ui/Window.cpp
@@ -1,0 +1,20 @@
+#include <app/ui/components/Window.hpp>
+
+namespace sauce::ui {
+
+Window::Window(const std::string& name, const std::string& title, ContentCallback content, 
+               ImGuiWindowFlags flags)
+    : ImGuiComponent(name), title(title), content(content), flags(flags) {}
+
+void Window::render() {
+    if (!enabled) return;
+    
+    if (ImGui::Begin(title.c_str(), &isOpen, flags)) {
+        if (content) {
+            content();
+        }
+    }
+    ImGui::End();
+}
+
+}


### PR DESCRIPTION
Added ImGui Layout & Containers component abstractions for the follow

- Window (Begin/End)
- ChildWindow (BeginChild/EndChild) 
- TreeNode (TreeNode/TreePop)
- CollapsingHeader
- Separator
- Spacing
- SameLine
- Columns (BeginColumns/EndColumns)
- Group (BeginGroup/EndGroup)

Please confirm if builds correctly. Was building fine on my windows pc but had some trouble on mac.