### PR TITLE
[#245] Light Components Depth Mapping Resources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ target_sources(${EXEC_NAME} PRIVATE
   src/app/components/TransformComponent.cpp
   src/app/components/RigidBodyComponent.cpp
   src/app/components/MeshRendererComponent.cpp
+  src/app/components/LightComponent.cpp
   src/app/components/PointLightComponent.cpp
   src/app/components/SpotLightComponent.cpp
   src/app/components/DirectionalLightComponent.cpp
@@ -168,6 +169,7 @@ target_sources(sauceeditor PRIVATE
     src/app/components/TransformComponent.cpp
     src/app/components/RigidBodyComponent.cpp
     src/app/components/MeshRendererComponent.cpp
+    src/app/components/LightComponent.cpp
     src/app/components/PointLightComponent.cpp
     src/app/components/SpotLightComponent.cpp
     src/app/components/DirectionalLightComponent.cpp

--- a/include/app/SauceEngineApp.hpp
+++ b/include/app/SauceEngineApp.hpp
@@ -92,6 +92,7 @@ private:
   void buildExampleUI();
 
   void uploadMeshGPUResources();
+  void uploadLightGPUResources();
   void setupSceneRenderer();
   void syncRigidBodiesToTransforms();
   void recordSceneCommandBuffer(vk::raii::CommandBuffer& cmd, uint32_t imageIndex);

--- a/include/app/components/DirectionalLightComponent.hpp
+++ b/include/app/components/DirectionalLightComponent.hpp
@@ -2,6 +2,14 @@
 
 #include "app/components/LightComponent.hpp"
 #include <glm/glm.hpp>
+#define VULKAN_HPP_NO_STRUCT_CONSTRUCTORS
+#include <vulkan/vulkan_raii.hpp>
+#include <memory>
+
+namespace sauce {
+    struct LogicalDevice;
+    struct PhysicalDevice;
+}
 
 namespace sauce {
 
@@ -21,10 +29,35 @@ public:
 
     GPULight toGPULight(const glm::vec3& worldPosition) const override;
 
+    // Depth mapping resources
+    static void initDescriptorSetLayout(const sauce::LogicalDevice& logicalDevice);
+    static const vk::raii::DescriptorSetLayout& getDescriptorSetLayout();
+    static void cleanup();
+
+    bool hasDepthMappingResources() const { return (bool)depthDescriptorSet; }
+    const vk::raii::DescriptorSet& getDepthDescriptorSet() const { return *depthDescriptorSet; }
+
+    void initDepthMappingResources(
+        const sauce::LogicalDevice& logicalDevice,
+        const sauce::PhysicalDevice& physicalDevice,
+        const vk::raii::CommandPool& commandPool,
+        const vk::raii::Queue& queue,
+        const vk::raii::DescriptorPool& descriptorPool,
+        const vk::raii::DescriptorSetLayout& layout
+    );
+
 private:
     glm::vec3 ambient{0.1f};
     glm::vec3 diffuse{1.0f};
     glm::vec3 specular{1.0f};
+
+    static std::unique_ptr<vk::raii::DescriptorSetLayout> descriptorSetLayout;
+
+    std::unique_ptr<vk::raii::Image> depthImage;
+    std::unique_ptr<vk::raii::DeviceMemory> depthImageMemory;
+    std::unique_ptr<vk::raii::ImageView> depthImageView;
+    std::unique_ptr<vk::raii::Sampler> depthSampler;
+    std::unique_ptr<vk::raii::DescriptorSet> depthDescriptorSet;
 };
 
 } // namespace sauce

--- a/include/app/components/DirectionalLightComponent.hpp
+++ b/include/app/components/DirectionalLightComponent.hpp
@@ -29,35 +29,17 @@ public:
 
     GPULight toGPULight(const glm::vec3& worldPosition) const override;
 
-    // Depth mapping resources
-    static void initDescriptorSetLayout(const sauce::LogicalDevice& logicalDevice);
-    static const vk::raii::DescriptorSetLayout& getDescriptorSetLayout();
-    static void cleanup();
-
-    bool hasDepthMappingResources() const { return (bool)depthDescriptorSet; }
-    const vk::raii::DescriptorSet& getDepthDescriptorSet() const { return *depthDescriptorSet; }
-
+    // Use base class implementation for depth mapping resources
     void initDepthMappingResources(
         const sauce::LogicalDevice& logicalDevice,
         const sauce::PhysicalDevice& physicalDevice,
-        const vk::raii::CommandPool& commandPool,
-        const vk::raii::Queue& queue,
-        const vk::raii::DescriptorPool& descriptorPool,
-        const vk::raii::DescriptorSetLayout& layout
+        const vk::raii::DescriptorPool& descriptorPool
     );
 
 private:
     glm::vec3 ambient{0.1f};
     glm::vec3 diffuse{1.0f};
     glm::vec3 specular{1.0f};
-
-    static std::unique_ptr<vk::raii::DescriptorSetLayout> descriptorSetLayout;
-
-    std::unique_ptr<vk::raii::Image> depthImage;
-    std::unique_ptr<vk::raii::DeviceMemory> depthImageMemory;
-    std::unique_ptr<vk::raii::ImageView> depthImageView;
-    std::unique_ptr<vk::raii::Sampler> depthSampler;
-    std::unique_ptr<vk::raii::DescriptorSet> depthDescriptorSet;
 };
 
 } // namespace sauce

--- a/include/app/components/LightComponent.hpp
+++ b/include/app/components/LightComponent.hpp
@@ -3,6 +3,14 @@
 #include "app/Component.hpp"
 #include <glm/glm.hpp>
 #include <cstdint>
+#define VULKAN_HPP_NO_STRUCT_CONSTRUCTORS
+#include <vulkan/vulkan_raii.hpp>
+#include <memory>
+
+namespace sauce {
+    struct LogicalDevice;
+    struct PhysicalDevice;
+}
 
 namespace sauce {
 
@@ -47,10 +55,34 @@ public:
 
     virtual GPULight toGPULight(const glm::vec3& worldPosition) const = 0;
 
+    bool hasDepthMappingResources() const { return (bool)depthDescriptorSet; }
+    const vk::raii::DescriptorSet& getDepthDescriptorSet() const { return *depthDescriptorSet; }
+
+    static void initDescriptorSetLayout(const sauce::LogicalDevice& logicalDevice);
+    static const vk::raii::DescriptorSetLayout& getDescriptorSetLayout();
+    static void cleanup();
+
 protected:
     LightType lightType;
     glm::vec3 color{1.0f};
     float intensity{1.0f};
+
+    // Shared Vulkan Resources
+    static std::unique_ptr<vk::raii::DescriptorSetLayout> descriptorSetLayout;
+    std::unique_ptr<vk::raii::Image> depthImage;
+    std::unique_ptr<vk::raii::DeviceMemory> depthImageMemory;
+    std::unique_ptr<vk::raii::ImageView> depthImageView;
+    std::unique_ptr<vk::raii::Sampler> depthSampler;
+    std::unique_ptr<vk::raii::DescriptorSet> depthDescriptorSet;
+
+    // A unified helper function for the derived classes to call
+    void allocateDepthMappingResources(
+        const sauce::LogicalDevice& logicalDevice,
+        const sauce::PhysicalDevice& physicalDevice,
+        const vk::raii::DescriptorPool& descriptorPool,
+        uint32_t resolution,
+        bool isCubeMap
+    );
 };
 
 } // namespace sauce

--- a/include/app/components/PointLightComponent.hpp
+++ b/include/app/components/PointLightComponent.hpp
@@ -64,21 +64,11 @@ public:
     GPUPointLight toGPUPointLight(const glm::vec3& worldPosition) const;
     GPULight toGPULight(const glm::vec3& worldPosition) const override;
 
-    // Depth mapping resources
-    static void initDescriptorSetLayout(const sauce::LogicalDevice& logicalDevice);
-    static const vk::raii::DescriptorSetLayout& getDescriptorSetLayout();
-    static void cleanup();
-
-    bool hasDepthMappingResources() const { return (bool)depthDescriptorSet; }
-    const vk::raii::DescriptorSet& getDepthDescriptorSet() const { return *depthDescriptorSet; }
-
+    // Use base class implementation for depth mapping resources
     void initDepthMappingResources(
         const sauce::LogicalDevice& logicalDevice,
         const sauce::PhysicalDevice& physicalDevice,
-        const vk::raii::CommandPool& commandPool,
-        const vk::raii::Queue& queue,
-        const vk::raii::DescriptorPool& descriptorPool,
-        const vk::raii::DescriptorSetLayout& layout
+        const vk::raii::DescriptorPool& descriptorPool
     );
 
 private:
@@ -90,14 +80,6 @@ private:
     float constant{1.0f};
     float linear{0.09f};
     float quadratic{0.032f};
-
-    static std::unique_ptr<vk::raii::DescriptorSetLayout> descriptorSetLayout;
-
-    std::unique_ptr<vk::raii::Image> depthImage;
-    std::unique_ptr<vk::raii::DeviceMemory> depthImageMemory;
-    std::unique_ptr<vk::raii::ImageView> depthImageView;
-    std::unique_ptr<vk::raii::Sampler> depthSampler;
-    std::unique_ptr<vk::raii::DescriptorSet> depthDescriptorSet;
 };
 
 } // namespace sauce

--- a/include/app/components/PointLightComponent.hpp
+++ b/include/app/components/PointLightComponent.hpp
@@ -2,6 +2,14 @@
 
 #include "app/components/LightComponent.hpp"
 #include <glm/glm.hpp>
+#define VULKAN_HPP_NO_STRUCT_CONSTRUCTORS
+#include <vulkan/vulkan_raii.hpp>
+#include <memory>
+
+namespace sauce {
+    struct LogicalDevice;
+    struct PhysicalDevice;
+}
 
 namespace sauce {
 
@@ -56,6 +64,23 @@ public:
     GPUPointLight toGPUPointLight(const glm::vec3& worldPosition) const;
     GPULight toGPULight(const glm::vec3& worldPosition) const override;
 
+    // Depth mapping resources
+    static void initDescriptorSetLayout(const sauce::LogicalDevice& logicalDevice);
+    static const vk::raii::DescriptorSetLayout& getDescriptorSetLayout();
+    static void cleanup();
+
+    bool hasDepthMappingResources() const { return (bool)depthDescriptorSet; }
+    const vk::raii::DescriptorSet& getDepthDescriptorSet() const { return *depthDescriptorSet; }
+
+    void initDepthMappingResources(
+        const sauce::LogicalDevice& logicalDevice,
+        const sauce::PhysicalDevice& physicalDevice,
+        const vk::raii::CommandPool& commandPool,
+        const vk::raii::Queue& queue,
+        const vk::raii::DescriptorPool& descriptorPool,
+        const vk::raii::DescriptorSetLayout& layout
+    );
+
 private:
     float range{0.0f};
 
@@ -65,6 +90,14 @@ private:
     float constant{1.0f};
     float linear{0.09f};
     float quadratic{0.032f};
+
+    static std::unique_ptr<vk::raii::DescriptorSetLayout> descriptorSetLayout;
+
+    std::unique_ptr<vk::raii::Image> depthImage;
+    std::unique_ptr<vk::raii::DeviceMemory> depthImageMemory;
+    std::unique_ptr<vk::raii::ImageView> depthImageView;
+    std::unique_ptr<vk::raii::Sampler> depthSampler;
+    std::unique_ptr<vk::raii::DescriptorSet> depthDescriptorSet;
 };
 
 } // namespace sauce

--- a/include/app/components/SpotLightComponent.hpp
+++ b/include/app/components/SpotLightComponent.hpp
@@ -49,21 +49,11 @@ public:
     GPUSpotLight toGPUSpotLight(const glm::vec3& worldPosition) const;
     GPULight toGPULight(const glm::vec3& worldPosition) const override;
 
-    // Depth mapping resources
-    static void initDescriptorSetLayout(const sauce::LogicalDevice& logicalDevice);
-    static const vk::raii::DescriptorSetLayout& getDescriptorSetLayout();
-    static void cleanup();
-
-    bool hasDepthMappingResources() const { return (bool)depthDescriptorSet; }
-    const vk::raii::DescriptorSet& getDepthDescriptorSet() const { return *depthDescriptorSet; }
-
+    // Use base class implementation for depth mapping resources
     void initDepthMappingResources(
         const sauce::LogicalDevice& logicalDevice,
         const sauce::PhysicalDevice& physicalDevice,
-        const vk::raii::CommandPool& commandPool,
-        const vk::raii::Queue& queue,
-        const vk::raii::DescriptorPool& descriptorPool,
-        const vk::raii::DescriptorSetLayout& layout
+        const vk::raii::DescriptorPool& descriptorPool
     );
 
 private:
@@ -71,14 +61,6 @@ private:
     glm::vec3 direction{0.0f, -1.0f, 0.0f};
     float innerConeAngle{0.0f};
     float outerConeAngle{0.7853981f}; // pi/4
-
-    static std::unique_ptr<vk::raii::DescriptorSetLayout> descriptorSetLayout;
-
-    std::unique_ptr<vk::raii::Image> depthImage;
-    std::unique_ptr<vk::raii::DeviceMemory> depthImageMemory;
-    std::unique_ptr<vk::raii::ImageView> depthImageView;
-    std::unique_ptr<vk::raii::Sampler> depthSampler;
-    std::unique_ptr<vk::raii::DescriptorSet> depthDescriptorSet;
 };
 
 }

--- a/include/app/components/SpotLightComponent.hpp
+++ b/include/app/components/SpotLightComponent.hpp
@@ -2,6 +2,14 @@
 
 #include "app/components/LightComponent.hpp"
 #include <glm/glm.hpp>
+#define VULKAN_HPP_NO_STRUCT_CONSTRUCTORS
+#include <vulkan/vulkan_raii.hpp>
+#include <memory>
+
+namespace sauce {
+    struct LogicalDevice;
+    struct PhysicalDevice;
+}
 
 namespace sauce {
 
@@ -41,11 +49,36 @@ public:
     GPUSpotLight toGPUSpotLight(const glm::vec3& worldPosition) const;
     GPULight toGPULight(const glm::vec3& worldPosition) const override;
 
+    // Depth mapping resources
+    static void initDescriptorSetLayout(const sauce::LogicalDevice& logicalDevice);
+    static const vk::raii::DescriptorSetLayout& getDescriptorSetLayout();
+    static void cleanup();
+
+    bool hasDepthMappingResources() const { return (bool)depthDescriptorSet; }
+    const vk::raii::DescriptorSet& getDepthDescriptorSet() const { return *depthDescriptorSet; }
+
+    void initDepthMappingResources(
+        const sauce::LogicalDevice& logicalDevice,
+        const sauce::PhysicalDevice& physicalDevice,
+        const vk::raii::CommandPool& commandPool,
+        const vk::raii::Queue& queue,
+        const vk::raii::DescriptorPool& descriptorPool,
+        const vk::raii::DescriptorSetLayout& layout
+    );
+
 private:
     float range{0.0f};
     glm::vec3 direction{0.0f, -1.0f, 0.0f};
     float innerConeAngle{0.0f};
     float outerConeAngle{0.7853981f}; // pi/4
+
+    static std::unique_ptr<vk::raii::DescriptorSetLayout> descriptorSetLayout;
+
+    std::unique_ptr<vk::raii::Image> depthImage;
+    std::unique_ptr<vk::raii::DeviceMemory> depthImageMemory;
+    std::unique_ptr<vk::raii::ImageView> depthImageView;
+    std::unique_ptr<vk::raii::Sampler> depthSampler;
+    std::unique_ptr<vk::raii::DescriptorSet> depthDescriptorSet;
 };
 
 }

--- a/src/app/SauceEngineApp.cpp
+++ b/src/app/SauceEngineApp.cpp
@@ -5,6 +5,9 @@
 #include <app/components/RigidBodyComponent.hpp>
 #include <app/components/MeshRendererComponent.hpp>
 #include <app/components/LightComponent.hpp>
+#include <app/components/DirectionalLightComponent.hpp>
+#include <app/components/PointLightComponent.hpp>
+#include <app/components/SpotLightComponent.hpp>
 #include <functional>
 #include <cstring>
 
@@ -27,6 +30,7 @@ void SauceEngineApp::run() {
   if (!sceneFile.empty() && pScene) {
     if (pScene->loadFromFile(sceneFile) && !pScene->getEntities().empty()) {
       uploadMeshGPUResources();
+      uploadLightGPUResources();
       setupSceneRenderer();
     }
   }
@@ -223,6 +227,41 @@ void SauceEngineApp::uploadMeshGPUResources() {
           pRenderer->getDefaultImageView(),
           pRenderer->getDefaultSampler()
         );
+      }
+    }
+  }
+}
+
+void SauceEngineApp::uploadLightGPUResources() {
+  if (!pScene) return;
+
+  auto& physDev = const_cast<vk::raii::PhysicalDevice&>(*physicalDevice);
+  auto& cmdPool = const_cast<vk::raii::CommandPool&>(pRenderer->getCommandPool());
+  auto& queue = const_cast<vk::raii::Queue&>(pRenderer->getQueue());
+  auto& logicalDev = logicalDevice;
+  auto& descriptorPool = pRenderer->getDescriptorPool();
+
+  DirectionalLightComponent::initDescriptorSetLayout(logicalDev);
+  PointLightComponent::initDescriptorSetLayout(logicalDev);
+  SpotLightComponent::initDescriptorSetLayout(logicalDev);
+
+  for (auto& entity : pScene->getEntitiesMut()) {
+    auto dirLights = entity.getComponents<DirectionalLightComponent>();
+    for (auto* dl : dirLights) {
+      if (!dl->hasDepthMappingResources()) {
+        dl->initDepthMappingResources(logicalDev, physDev, cmdPool, queue, descriptorPool, DirectionalLightComponent::getDescriptorSetLayout());
+      }
+    }
+    auto ptLights = entity.getComponents<PointLightComponent>();
+    for (auto* pl : ptLights) {
+      if (!pl->hasDepthMappingResources()) {
+        pl->initDepthMappingResources(logicalDev, physDev, cmdPool, queue, descriptorPool, PointLightComponent::getDescriptorSetLayout());
+      }
+    }
+    auto spLights = entity.getComponents<SpotLightComponent>();
+    for (auto* sl : spLights) {
+      if (!sl->hasDepthMappingResources()) {
+        sl->initDepthMappingResources(logicalDev, physDev, cmdPool, queue, descriptorPool, SpotLightComponent::getDescriptorSetLayout());
       }
     }
   }

--- a/src/app/SauceEngineApp.cpp
+++ b/src/app/SauceEngineApp.cpp
@@ -18,6 +18,7 @@ SauceEngineApp::SauceEngineApp() {
 }
 
 SauceEngineApp::~SauceEngineApp() {
+    LightComponent::cleanup();
     glfwDestroyWindow(window);
     glfwTerminate();
 }
@@ -73,6 +74,9 @@ void SauceEngineApp::initVulkan() {
     };
 
     pRenderer = std::make_unique<sauce::Renderer>(rendererCreateInfo);
+
+    // Init shadow mapping descriptor set layout
+    LightComponent::initDescriptorSetLayout(logicalDevice);
 
     // Initialize ImGui
     sauce::ImGuiRendererCreateInfo imguiCreateInfo{
@@ -240,8 +244,6 @@ void SauceEngineApp::uploadLightGPUResources() {
   auto& queue = const_cast<vk::raii::Queue&>(pRenderer->getQueue());
   auto& logicalDev = logicalDevice;
   auto& descriptorPool = pRenderer->getDescriptorPool();
-
-  LightComponent::initDescriptorSetLayout(logicalDev);
 
   for (auto& entity : pScene->getEntitiesMut()) {
     auto lights = entity.getComponents<LightComponent>();

--- a/src/app/SauceEngineApp.cpp
+++ b/src/app/SauceEngineApp.cpp
@@ -241,27 +241,19 @@ void SauceEngineApp::uploadLightGPUResources() {
   auto& logicalDev = logicalDevice;
   auto& descriptorPool = pRenderer->getDescriptorPool();
 
-  DirectionalLightComponent::initDescriptorSetLayout(logicalDev);
-  PointLightComponent::initDescriptorSetLayout(logicalDev);
-  SpotLightComponent::initDescriptorSetLayout(logicalDev);
+  LightComponent::initDescriptorSetLayout(logicalDev);
 
   for (auto& entity : pScene->getEntitiesMut()) {
-    auto dirLights = entity.getComponents<DirectionalLightComponent>();
-    for (auto* dl : dirLights) {
-      if (!dl->hasDepthMappingResources()) {
-        dl->initDepthMappingResources(logicalDev, physDev, cmdPool, queue, descriptorPool, DirectionalLightComponent::getDescriptorSetLayout());
-      }
-    }
-    auto ptLights = entity.getComponents<PointLightComponent>();
-    for (auto* pl : ptLights) {
-      if (!pl->hasDepthMappingResources()) {
-        pl->initDepthMappingResources(logicalDev, physDev, cmdPool, queue, descriptorPool, PointLightComponent::getDescriptorSetLayout());
-      }
-    }
-    auto spLights = entity.getComponents<SpotLightComponent>();
-    for (auto* sl : spLights) {
-      if (!sl->hasDepthMappingResources()) {
-        sl->initDepthMappingResources(logicalDev, physDev, cmdPool, queue, descriptorPool, SpotLightComponent::getDescriptorSetLayout());
+    auto lights = entity.getComponents<LightComponent>();
+    for (auto* light : lights) {
+      if (!light->hasDepthMappingResources()) {
+        if (auto* dl = dynamic_cast<DirectionalLightComponent*>(light)) {
+          dl->initDepthMappingResources(logicalDev, physDev, descriptorPool);
+        } else if (auto* pl = dynamic_cast<PointLightComponent*>(light)) {
+          pl->initDepthMappingResources(logicalDev, physDev, descriptorPool);
+        } else if (auto* sl = dynamic_cast<SpotLightComponent*>(light)) {
+          sl->initDepthMappingResources(logicalDev, physDev, descriptorPool);
+        }
       }
     }
   }

--- a/src/app/components/DirectionalLightComponent.cpp
+++ b/src/app/components/DirectionalLightComponent.cpp
@@ -1,6 +1,9 @@
 #include "app/components/DirectionalLightComponent.hpp"
+#include "app/ImageUtils.hpp"
 
 namespace sauce {
+
+std::unique_ptr<vk::raii::DescriptorSetLayout> DirectionalLightComponent::descriptorSetLayout = nullptr;
 
 DirectionalLightComponent::DirectionalLightComponent()
     : LightComponent(LightType::Directional, "DirectionalLightComponent") {}
@@ -23,6 +26,104 @@ GPULight DirectionalLightComponent::toGPULight(const glm::vec3& worldPosition) c
     gpu.innerConeAngle = 0.0f;
     gpu.outerConeAngle = 0.0f;
     return gpu;
+}
+
+void DirectionalLightComponent::initDescriptorSetLayout(const sauce::LogicalDevice& logicalDevice) {
+    if (descriptorSetLayout) return;
+
+    vk::DescriptorSetLayoutBinding shadowBinding {
+        .binding = 0,
+        .descriptorType = vk::DescriptorType::eCombinedImageSampler,
+        .descriptorCount = 1,
+        .stageFlags = vk::ShaderStageFlagBits::eFragment
+    };
+
+    vk::DescriptorSetLayoutCreateInfo layoutInfo {
+        .bindingCount = 1,
+        .pBindings = &shadowBinding,
+    };
+    descriptorSetLayout = std::make_unique<vk::raii::DescriptorSetLayout>(*logicalDevice, layoutInfo);
+}
+
+const vk::raii::DescriptorSetLayout& DirectionalLightComponent::getDescriptorSetLayout() {
+    return *descriptorSetLayout;
+}
+
+void DirectionalLightComponent::cleanup() {
+    descriptorSetLayout.reset();
+}
+
+void DirectionalLightComponent::initDepthMappingResources(
+    const sauce::LogicalDevice& logicalDevice,
+    const sauce::PhysicalDevice& physicalDevice,
+    const vk::raii::CommandPool& commandPool,
+    const vk::raii::Queue& queue,
+    const vk::raii::DescriptorPool& descriptorPool,
+    const vk::raii::DescriptorSetLayout& layout)
+{
+    if (depthImage) return;
+
+    uint32_t width = 2048;
+    uint32_t height = 2048;
+
+    depthImage = std::make_unique<vk::raii::Image>(nullptr);
+    depthImageMemory = std::make_unique<vk::raii::DeviceMemory>(nullptr);
+
+    vk::Format depthFormat = vk::Format::eD32Sfloat;
+
+    sauce::ImageUtils::createImage(
+        physicalDevice, logicalDevice,
+        width, height, depthFormat,
+        vk::ImageTiling::eOptimal,
+        vk::ImageUsageFlagBits::eDepthStencilAttachment | vk::ImageUsageFlagBits::eSampled,
+        vk::MemoryPropertyFlagBits::eDeviceLocal,
+        *depthImage, *depthImageMemory
+    );
+
+    depthImageView = std::make_unique<vk::raii::ImageView>(
+        sauce::ImageUtils::createImageView(
+            logicalDevice, *depthImage, depthFormat,
+            vk::ImageAspectFlagBits::eDepth
+        )
+    );
+
+    vk::SamplerCreateInfo samplerInfo{};
+    samplerInfo.magFilter = vk::Filter::eLinear;
+    samplerInfo.minFilter = vk::Filter::eLinear;
+    samplerInfo.mipmapMode = vk::SamplerMipmapMode::eLinear;
+    samplerInfo.addressModeU = vk::SamplerAddressMode::eClampToEdge;
+    samplerInfo.addressModeV = vk::SamplerAddressMode::eClampToEdge;
+    samplerInfo.addressModeW = vk::SamplerAddressMode::eClampToEdge;
+    samplerInfo.compareEnable = VK_TRUE;
+    samplerInfo.compareOp = vk::CompareOp::eLessOrEqual;
+    samplerInfo.borderColor = vk::BorderColor::eFloatOpaqueWhite;
+
+    depthSampler = std::make_unique<vk::raii::Sampler>(*logicalDevice, samplerInfo);
+
+    vk::DescriptorSetAllocateInfo allocInfo {
+        .descriptorPool = *descriptorPool,
+        .descriptorSetCount = 1,
+        .pSetLayouts = &*layout,
+    };
+
+    auto sets = logicalDevice->allocateDescriptorSets(allocInfo);
+    depthDescriptorSet = std::make_unique<vk::raii::DescriptorSet>(std::move(sets[0]));
+
+    vk::DescriptorImageInfo imageInfo {
+        .sampler = **depthSampler,
+        .imageView = **depthImageView,
+        .imageLayout = vk::ImageLayout::eDepthStencilReadOnlyOptimal
+    };
+
+    vk::WriteDescriptorSet write {
+        .dstSet = **depthDescriptorSet,
+        .dstBinding = 0,
+        .descriptorCount = 1,
+        .descriptorType = vk::DescriptorType::eCombinedImageSampler,
+        .pImageInfo = &imageInfo
+    };
+
+    logicalDevice->updateDescriptorSets(write, {});
 }
 
 } // namespace sauce

--- a/src/app/components/DirectionalLightComponent.cpp
+++ b/src/app/components/DirectionalLightComponent.cpp
@@ -1,9 +1,8 @@
 #include "app/components/DirectionalLightComponent.hpp"
+#include "app/components/LightComponent.hpp"
 #include "app/ImageUtils.hpp"
 
 namespace sauce {
-
-std::unique_ptr<vk::raii::DescriptorSetLayout> DirectionalLightComponent::descriptorSetLayout = nullptr;
 
 DirectionalLightComponent::DirectionalLightComponent()
     : LightComponent(LightType::Directional, "DirectionalLightComponent") {}
@@ -28,102 +27,12 @@ GPULight DirectionalLightComponent::toGPULight(const glm::vec3& worldPosition) c
     return gpu;
 }
 
-void DirectionalLightComponent::initDescriptorSetLayout(const sauce::LogicalDevice& logicalDevice) {
-    if (descriptorSetLayout) return;
-
-    vk::DescriptorSetLayoutBinding shadowBinding {
-        .binding = 0,
-        .descriptorType = vk::DescriptorType::eCombinedImageSampler,
-        .descriptorCount = 1,
-        .stageFlags = vk::ShaderStageFlagBits::eFragment
-    };
-
-    vk::DescriptorSetLayoutCreateInfo layoutInfo {
-        .bindingCount = 1,
-        .pBindings = &shadowBinding,
-    };
-    descriptorSetLayout = std::make_unique<vk::raii::DescriptorSetLayout>(*logicalDevice, layoutInfo);
-}
-
-const vk::raii::DescriptorSetLayout& DirectionalLightComponent::getDescriptorSetLayout() {
-    return *descriptorSetLayout;
-}
-
-void DirectionalLightComponent::cleanup() {
-    descriptorSetLayout.reset();
-}
-
 void DirectionalLightComponent::initDepthMappingResources(
     const sauce::LogicalDevice& logicalDevice,
     const sauce::PhysicalDevice& physicalDevice,
-    const vk::raii::CommandPool& commandPool,
-    const vk::raii::Queue& queue,
-    const vk::raii::DescriptorPool& descriptorPool,
-    const vk::raii::DescriptorSetLayout& layout)
+    const vk::raii::DescriptorPool& descriptorPool)
 {
-    if (depthImage) return;
-
-    uint32_t width = 2048;
-    uint32_t height = 2048;
-
-    depthImage = std::make_unique<vk::raii::Image>(nullptr);
-    depthImageMemory = std::make_unique<vk::raii::DeviceMemory>(nullptr);
-
-    vk::Format depthFormat = vk::Format::eD32Sfloat;
-
-    sauce::ImageUtils::createImage(
-        physicalDevice, logicalDevice,
-        width, height, depthFormat,
-        vk::ImageTiling::eOptimal,
-        vk::ImageUsageFlagBits::eDepthStencilAttachment | vk::ImageUsageFlagBits::eSampled,
-        vk::MemoryPropertyFlagBits::eDeviceLocal,
-        *depthImage, *depthImageMemory
-    );
-
-    depthImageView = std::make_unique<vk::raii::ImageView>(
-        sauce::ImageUtils::createImageView(
-            logicalDevice, *depthImage, depthFormat,
-            vk::ImageAspectFlagBits::eDepth
-        )
-    );
-
-    vk::SamplerCreateInfo samplerInfo{};
-    samplerInfo.magFilter = vk::Filter::eLinear;
-    samplerInfo.minFilter = vk::Filter::eLinear;
-    samplerInfo.mipmapMode = vk::SamplerMipmapMode::eLinear;
-    samplerInfo.addressModeU = vk::SamplerAddressMode::eClampToEdge;
-    samplerInfo.addressModeV = vk::SamplerAddressMode::eClampToEdge;
-    samplerInfo.addressModeW = vk::SamplerAddressMode::eClampToEdge;
-    samplerInfo.compareEnable = VK_TRUE;
-    samplerInfo.compareOp = vk::CompareOp::eLessOrEqual;
-    samplerInfo.borderColor = vk::BorderColor::eFloatOpaqueWhite;
-
-    depthSampler = std::make_unique<vk::raii::Sampler>(*logicalDevice, samplerInfo);
-
-    vk::DescriptorSetAllocateInfo allocInfo {
-        .descriptorPool = *descriptorPool,
-        .descriptorSetCount = 1,
-        .pSetLayouts = &*layout,
-    };
-
-    auto sets = logicalDevice->allocateDescriptorSets(allocInfo);
-    depthDescriptorSet = std::make_unique<vk::raii::DescriptorSet>(std::move(sets[0]));
-
-    vk::DescriptorImageInfo imageInfo {
-        .sampler = **depthSampler,
-        .imageView = **depthImageView,
-        .imageLayout = vk::ImageLayout::eDepthStencilReadOnlyOptimal
-    };
-
-    vk::WriteDescriptorSet write {
-        .dstSet = **depthDescriptorSet,
-        .dstBinding = 0,
-        .descriptorCount = 1,
-        .descriptorType = vk::DescriptorType::eCombinedImageSampler,
-        .pImageInfo = &imageInfo
-    };
-
-    logicalDevice->updateDescriptorSets(write, {});
+    allocateDepthMappingResources(logicalDevice, physicalDevice, descriptorPool, 2048, false);
 }
 
 } // namespace sauce

--- a/src/app/components/LightComponent.cpp
+++ b/src/app/components/LightComponent.cpp
@@ -1,0 +1,109 @@
+#include "app/components/LightComponent.hpp"
+#include "app/ImageUtils.hpp"
+#include "app/LogicalDevice.hpp"
+#include "app/PhysicalDevice.hpp"
+
+namespace sauce {
+
+std::unique_ptr<vk::raii::DescriptorSetLayout> LightComponent::descriptorSetLayout = nullptr;
+
+void LightComponent::initDescriptorSetLayout(const sauce::LogicalDevice& logicalDevice) {
+    if (descriptorSetLayout) return;
+
+    vk::DescriptorSetLayoutBinding shadowBinding {
+        .binding = 0,
+        .descriptorType = vk::DescriptorType::eCombinedImageSampler,
+        .descriptorCount = 1,
+        .stageFlags = vk::ShaderStageFlagBits::eFragment,
+    };
+
+    vk::DescriptorSetLayoutCreateInfo layoutInfo {
+        .bindingCount = 1,
+        .pBindings = &shadowBinding,
+    };
+    descriptorSetLayout = std::make_unique<vk::raii::DescriptorSetLayout>(*logicalDevice, layoutInfo);
+}
+
+const vk::raii::DescriptorSetLayout& LightComponent::getDescriptorSetLayout() {
+    return *descriptorSetLayout;
+}
+
+void LightComponent::cleanup() {
+    descriptorSetLayout.reset();
+}
+
+void LightComponent::allocateDepthMappingResources(
+    const sauce::LogicalDevice& logicalDevice,
+    const sauce::PhysicalDevice& physicalDevice,
+    const vk::raii::DescriptorPool& descriptorPool,
+    uint32_t resolution,
+    bool isCubeMap) 
+{
+    if (depthImage) return;
+
+    depthImage = std::make_unique<vk::raii::Image>(nullptr);
+    depthImageMemory = std::make_unique<vk::raii::DeviceMemory>(nullptr);
+
+    vk::Format depthFormat = vk::Format::eD32Sfloat;
+    uint32_t layers = isCubeMap ? 6 : 1;
+    vk::ImageCreateFlags createFlags = isCubeMap ? vk::ImageCreateFlagBits::eCubeCompatible : vk::ImageCreateFlags{};
+
+    sauce::ImageUtils::createImage(
+        physicalDevice, logicalDevice,
+        resolution, resolution, depthFormat,
+        vk::ImageTiling::eOptimal,
+        vk::ImageUsageFlagBits::eDepthStencilAttachment | vk::ImageUsageFlagBits::eSampled,
+        vk::MemoryPropertyFlagBits::eDeviceLocal,
+        *depthImage, *depthImageMemory,
+        1, layers, createFlags
+    );
+
+    vk::ImageViewType viewType = isCubeMap ? vk::ImageViewType::eCube : vk::ImageViewType::e2D;
+
+    depthImageView = std::make_unique<vk::raii::ImageView>(
+        sauce::ImageUtils::createImageView(
+            logicalDevice, *depthImage, depthFormat,
+            vk::ImageAspectFlagBits::eDepth,
+            viewType, 1, layers
+        )
+    );
+
+    vk::SamplerCreateInfo samplerInfo{};
+    samplerInfo.magFilter = vk::Filter::eLinear;
+    samplerInfo.minFilter = vk::Filter::eLinear;
+    samplerInfo.mipmapMode = vk::SamplerMipmapMode::eLinear;
+    samplerInfo.addressModeU = vk::SamplerAddressMode::eClampToEdge;
+    samplerInfo.addressModeV = vk::SamplerAddressMode::eClampToEdge;
+    samplerInfo.addressModeW = vk::SamplerAddressMode::eClampToEdge;
+    samplerInfo.compareEnable = VK_TRUE;
+    samplerInfo.compareOp = vk::CompareOp::eLessOrEqual;
+    samplerInfo.borderColor = vk::BorderColor::eFloatOpaqueWhite;
+
+    depthSampler = std::make_unique<vk::raii::Sampler>(*logicalDevice, samplerInfo);
+
+    vk::DescriptorSetAllocateInfo allocInfo {
+        .descriptorPool = *descriptorPool,
+        .descriptorSetCount = 1,
+        .pSetLayouts = &**descriptorSetLayout, // Grab the unified layout
+    };
+
+    auto sets = logicalDevice->allocateDescriptorSets(allocInfo);
+    depthDescriptorSet = std::make_unique<vk::raii::DescriptorSet>(std::move(sets[0]));
+
+    vk::DescriptorImageInfo imageInfo {
+        .sampler = **depthSampler,
+        .imageView = **depthImageView,
+        .imageLayout = vk::ImageLayout::eDepthStencilReadOnlyOptimal
+    };
+
+    vk::WriteDescriptorSet write {
+        .dstSet = **depthDescriptorSet,
+        .dstBinding = 0,
+        .descriptorCount = 1,
+        .descriptorType = vk::DescriptorType::eCombinedImageSampler,
+        .pImageInfo = &imageInfo
+    };
+
+    logicalDevice->updateDescriptorSets(write, {});
+}
+}

--- a/src/app/components/PointLightComponent.cpp
+++ b/src/app/components/PointLightComponent.cpp
@@ -1,9 +1,8 @@
 #include "app/components/PointLightComponent.hpp"
+#include "app/components/LightComponent.hpp"
 #include "app/ImageUtils.hpp"
 
 namespace sauce {
-
-std::unique_ptr<vk::raii::DescriptorSetLayout> PointLightComponent::descriptorSetLayout = nullptr;
 
 PointLightComponent::PointLightComponent()
     : LightComponent(LightType::Point, "PointLightComponent") {}
@@ -42,105 +41,12 @@ GPULight PointLightComponent::toGPULight(const glm::vec3& worldPosition) const {
     return gpu;
 }
 
-void PointLightComponent::initDescriptorSetLayout(const sauce::LogicalDevice& logicalDevice) {
-    if (descriptorSetLayout) return;
-
-    vk::DescriptorSetLayoutBinding shadowBinding {
-        .binding = 0,
-        .descriptorType = vk::DescriptorType::eCombinedImageSampler,
-        .descriptorCount = 1,
-        .stageFlags = vk::ShaderStageFlagBits::eFragment
-    };
-
-    vk::DescriptorSetLayoutCreateInfo layoutInfo {
-        .bindingCount = 1,
-        .pBindings = &shadowBinding,
-    };
-    descriptorSetLayout = std::make_unique<vk::raii::DescriptorSetLayout>(*logicalDevice, layoutInfo);
-}
-
-const vk::raii::DescriptorSetLayout& PointLightComponent::getDescriptorSetLayout() {
-    return *descriptorSetLayout;
-}
-
-void PointLightComponent::cleanup() {
-    descriptorSetLayout.reset();
-}
-
 void PointLightComponent::initDepthMappingResources(
     const sauce::LogicalDevice& logicalDevice,
     const sauce::PhysicalDevice& physicalDevice,
-    const vk::raii::CommandPool& commandPool,
-    const vk::raii::Queue& queue,
-    const vk::raii::DescriptorPool& descriptorPool,
-    const vk::raii::DescriptorSetLayout& layout)
+    const vk::raii::DescriptorPool& descriptorPool)
 {
-    if (depthImage) return;
-
-    uint32_t width = 1024;
-    uint32_t height = 1024;
-
-    depthImage = std::make_unique<vk::raii::Image>(nullptr);
-    depthImageMemory = std::make_unique<vk::raii::DeviceMemory>(nullptr);
-
-    vk::Format depthFormat = vk::Format::eD32Sfloat;
-
-    sauce::ImageUtils::createImage(
-        physicalDevice, logicalDevice,
-        width, height, depthFormat,
-        vk::ImageTiling::eOptimal,
-        vk::ImageUsageFlagBits::eDepthStencilAttachment | vk::ImageUsageFlagBits::eSampled,
-        vk::MemoryPropertyFlagBits::eDeviceLocal,
-        *depthImage, *depthImageMemory,
-        1, 6, vk::ImageCreateFlagBits::eCubeCompatible
-    );
-
-    depthImageView = std::make_unique<vk::raii::ImageView>(
-        sauce::ImageUtils::createImageView(
-            logicalDevice, *depthImage, depthFormat,
-            vk::ImageAspectFlagBits::eDepth,
-            vk::ImageViewType::eCube,
-            1, 6
-        )
-    );
-
-    vk::SamplerCreateInfo samplerInfo{};
-    samplerInfo.magFilter = vk::Filter::eLinear;
-    samplerInfo.minFilter = vk::Filter::eLinear;
-    samplerInfo.mipmapMode = vk::SamplerMipmapMode::eLinear;
-    samplerInfo.addressModeU = vk::SamplerAddressMode::eClampToEdge;
-    samplerInfo.addressModeV = vk::SamplerAddressMode::eClampToEdge;
-    samplerInfo.addressModeW = vk::SamplerAddressMode::eClampToEdge;
-    samplerInfo.compareEnable = VK_TRUE;
-    samplerInfo.compareOp = vk::CompareOp::eLessOrEqual;
-    samplerInfo.borderColor = vk::BorderColor::eFloatOpaqueWhite;
-
-    depthSampler = std::make_unique<vk::raii::Sampler>(*logicalDevice, samplerInfo);
-
-    vk::DescriptorSetAllocateInfo allocInfo {
-        .descriptorPool = *descriptorPool,
-        .descriptorSetCount = 1,
-        .pSetLayouts = &*layout,
-    };
-
-    auto sets = logicalDevice->allocateDescriptorSets(allocInfo);
-    depthDescriptorSet = std::make_unique<vk::raii::DescriptorSet>(std::move(sets[0]));
-
-    vk::DescriptorImageInfo imageInfo {
-        .sampler = **depthSampler,
-        .imageView = **depthImageView,
-        .imageLayout = vk::ImageLayout::eDepthStencilReadOnlyOptimal
-    };
-
-    vk::WriteDescriptorSet write {
-        .dstSet = **depthDescriptorSet,
-        .dstBinding = 0,
-        .descriptorCount = 1,
-        .descriptorType = vk::DescriptorType::eCombinedImageSampler,
-        .pImageInfo = &imageInfo
-    };
-
-    logicalDevice->updateDescriptorSets(write, {});
+    allocateDepthMappingResources(logicalDevice, physicalDevice, descriptorPool, 1024, true);
 }
 
 } // namespace sauce

--- a/src/app/components/PointLightComponent.cpp
+++ b/src/app/components/PointLightComponent.cpp
@@ -1,6 +1,9 @@
 #include "app/components/PointLightComponent.hpp"
+#include "app/ImageUtils.hpp"
 
 namespace sauce {
+
+std::unique_ptr<vk::raii::DescriptorSetLayout> PointLightComponent::descriptorSetLayout = nullptr;
 
 PointLightComponent::PointLightComponent()
     : LightComponent(LightType::Point, "PointLightComponent") {}
@@ -37,6 +40,107 @@ GPULight PointLightComponent::toGPULight(const glm::vec3& worldPosition) const {
     gpu.innerConeAngle = 0.0f;
     gpu.outerConeAngle = 0.0f;
     return gpu;
+}
+
+void PointLightComponent::initDescriptorSetLayout(const sauce::LogicalDevice& logicalDevice) {
+    if (descriptorSetLayout) return;
+
+    vk::DescriptorSetLayoutBinding shadowBinding {
+        .binding = 0,
+        .descriptorType = vk::DescriptorType::eCombinedImageSampler,
+        .descriptorCount = 1,
+        .stageFlags = vk::ShaderStageFlagBits::eFragment
+    };
+
+    vk::DescriptorSetLayoutCreateInfo layoutInfo {
+        .bindingCount = 1,
+        .pBindings = &shadowBinding,
+    };
+    descriptorSetLayout = std::make_unique<vk::raii::DescriptorSetLayout>(*logicalDevice, layoutInfo);
+}
+
+const vk::raii::DescriptorSetLayout& PointLightComponent::getDescriptorSetLayout() {
+    return *descriptorSetLayout;
+}
+
+void PointLightComponent::cleanup() {
+    descriptorSetLayout.reset();
+}
+
+void PointLightComponent::initDepthMappingResources(
+    const sauce::LogicalDevice& logicalDevice,
+    const sauce::PhysicalDevice& physicalDevice,
+    const vk::raii::CommandPool& commandPool,
+    const vk::raii::Queue& queue,
+    const vk::raii::DescriptorPool& descriptorPool,
+    const vk::raii::DescriptorSetLayout& layout)
+{
+    if (depthImage) return;
+
+    uint32_t width = 1024;
+    uint32_t height = 1024;
+
+    depthImage = std::make_unique<vk::raii::Image>(nullptr);
+    depthImageMemory = std::make_unique<vk::raii::DeviceMemory>(nullptr);
+
+    vk::Format depthFormat = vk::Format::eD32Sfloat;
+
+    sauce::ImageUtils::createImage(
+        physicalDevice, logicalDevice,
+        width, height, depthFormat,
+        vk::ImageTiling::eOptimal,
+        vk::ImageUsageFlagBits::eDepthStencilAttachment | vk::ImageUsageFlagBits::eSampled,
+        vk::MemoryPropertyFlagBits::eDeviceLocal,
+        *depthImage, *depthImageMemory,
+        1, 6, vk::ImageCreateFlagBits::eCubeCompatible
+    );
+
+    depthImageView = std::make_unique<vk::raii::ImageView>(
+        sauce::ImageUtils::createImageView(
+            logicalDevice, *depthImage, depthFormat,
+            vk::ImageAspectFlagBits::eDepth,
+            vk::ImageViewType::eCube,
+            1, 6
+        )
+    );
+
+    vk::SamplerCreateInfo samplerInfo{};
+    samplerInfo.magFilter = vk::Filter::eLinear;
+    samplerInfo.minFilter = vk::Filter::eLinear;
+    samplerInfo.mipmapMode = vk::SamplerMipmapMode::eLinear;
+    samplerInfo.addressModeU = vk::SamplerAddressMode::eClampToEdge;
+    samplerInfo.addressModeV = vk::SamplerAddressMode::eClampToEdge;
+    samplerInfo.addressModeW = vk::SamplerAddressMode::eClampToEdge;
+    samplerInfo.compareEnable = VK_TRUE;
+    samplerInfo.compareOp = vk::CompareOp::eLessOrEqual;
+    samplerInfo.borderColor = vk::BorderColor::eFloatOpaqueWhite;
+
+    depthSampler = std::make_unique<vk::raii::Sampler>(*logicalDevice, samplerInfo);
+
+    vk::DescriptorSetAllocateInfo allocInfo {
+        .descriptorPool = *descriptorPool,
+        .descriptorSetCount = 1,
+        .pSetLayouts = &*layout,
+    };
+
+    auto sets = logicalDevice->allocateDescriptorSets(allocInfo);
+    depthDescriptorSet = std::make_unique<vk::raii::DescriptorSet>(std::move(sets[0]));
+
+    vk::DescriptorImageInfo imageInfo {
+        .sampler = **depthSampler,
+        .imageView = **depthImageView,
+        .imageLayout = vk::ImageLayout::eDepthStencilReadOnlyOptimal
+    };
+
+    vk::WriteDescriptorSet write {
+        .dstSet = **depthDescriptorSet,
+        .dstBinding = 0,
+        .descriptorCount = 1,
+        .descriptorType = vk::DescriptorType::eCombinedImageSampler,
+        .pImageInfo = &imageInfo
+    };
+
+    logicalDevice->updateDescriptorSets(write, {});
 }
 
 } // namespace sauce

--- a/src/app/components/SpotLightComponent.cpp
+++ b/src/app/components/SpotLightComponent.cpp
@@ -1,9 +1,8 @@
 #include "app/components/SpotLightComponent.hpp"
+#include "app/components/LightComponent.hpp"
 #include "app/ImageUtils.hpp"
 
 namespace sauce {
-
-std::unique_ptr<vk::raii::DescriptorSetLayout> SpotLightComponent::descriptorSetLayout = nullptr;
 
 SpotLightComponent::SpotLightComponent()
     : LightComponent(LightType::Spot, "SpotLightComponent") {}
@@ -46,102 +45,12 @@ GPULight SpotLightComponent::toGPULight(const glm::vec3& worldPosition) const {
     return gpu;
 }
 
-void SpotLightComponent::initDescriptorSetLayout(const sauce::LogicalDevice& logicalDevice) {
-    if (descriptorSetLayout) return;
-
-    vk::DescriptorSetLayoutBinding shadowBinding {
-        .binding = 0,
-        .descriptorType = vk::DescriptorType::eCombinedImageSampler,
-        .descriptorCount = 1,
-        .stageFlags = vk::ShaderStageFlagBits::eFragment
-    };
-
-    vk::DescriptorSetLayoutCreateInfo layoutInfo {
-        .bindingCount = 1,
-        .pBindings = &shadowBinding,
-    };
-    descriptorSetLayout = std::make_unique<vk::raii::DescriptorSetLayout>(*logicalDevice, layoutInfo);
-}
-
-const vk::raii::DescriptorSetLayout& SpotLightComponent::getDescriptorSetLayout() {
-    return *descriptorSetLayout;
-}
-
-void SpotLightComponent::cleanup() {
-    descriptorSetLayout.reset();
-}
-
 void SpotLightComponent::initDepthMappingResources(
     const sauce::LogicalDevice& logicalDevice,
     const sauce::PhysicalDevice& physicalDevice,
-    const vk::raii::CommandPool& commandPool,
-    const vk::raii::Queue& queue,
-    const vk::raii::DescriptorPool& descriptorPool,
-    const vk::raii::DescriptorSetLayout& layout)
+    const vk::raii::DescriptorPool& descriptorPool)
 {
-    if (depthImage) return;
-
-    uint32_t width = 2048;
-    uint32_t height = 2048;
-
-    depthImage = std::make_unique<vk::raii::Image>(nullptr);
-    depthImageMemory = std::make_unique<vk::raii::DeviceMemory>(nullptr);
-
-    vk::Format depthFormat = vk::Format::eD32Sfloat;
-
-    sauce::ImageUtils::createImage(
-        physicalDevice, logicalDevice,
-        width, height, depthFormat,
-        vk::ImageTiling::eOptimal,
-        vk::ImageUsageFlagBits::eDepthStencilAttachment | vk::ImageUsageFlagBits::eSampled,
-        vk::MemoryPropertyFlagBits::eDeviceLocal,
-        *depthImage, *depthImageMemory
-    );
-
-    depthImageView = std::make_unique<vk::raii::ImageView>(
-        sauce::ImageUtils::createImageView(
-            logicalDevice, *depthImage, depthFormat,
-            vk::ImageAspectFlagBits::eDepth
-        )
-    );
-
-    vk::SamplerCreateInfo samplerInfo{};
-    samplerInfo.magFilter = vk::Filter::eLinear;
-    samplerInfo.minFilter = vk::Filter::eLinear;
-    samplerInfo.mipmapMode = vk::SamplerMipmapMode::eLinear;
-    samplerInfo.addressModeU = vk::SamplerAddressMode::eClampToEdge;
-    samplerInfo.addressModeV = vk::SamplerAddressMode::eClampToEdge;
-    samplerInfo.addressModeW = vk::SamplerAddressMode::eClampToEdge;
-    samplerInfo.compareEnable = VK_TRUE;
-    samplerInfo.compareOp = vk::CompareOp::eLessOrEqual;
-    samplerInfo.borderColor = vk::BorderColor::eFloatOpaqueWhite;
-
-    depthSampler = std::make_unique<vk::raii::Sampler>(*logicalDevice, samplerInfo);
-
-    vk::DescriptorSetAllocateInfo allocInfo {
-        .descriptorPool = *descriptorPool,
-        .descriptorSetCount = 1,
-        .pSetLayouts = &*layout,
-    };
-
-    auto sets = logicalDevice->allocateDescriptorSets(allocInfo);
-    depthDescriptorSet = std::make_unique<vk::raii::DescriptorSet>(std::move(sets[0]));
-
-    vk::DescriptorImageInfo imageInfo {
-        .sampler = **depthSampler,
-        .imageView = **depthImageView,
-        .imageLayout = vk::ImageLayout::eDepthStencilReadOnlyOptimal
-    };
-
-    vk::WriteDescriptorSet write {
-        .dstSet = **depthDescriptorSet,
-        .dstBinding = 0,
-        .descriptorCount = 1,
-        .descriptorType = vk::DescriptorType::eCombinedImageSampler,
-        .pImageInfo = &imageInfo
-    };
-
-    logicalDevice->updateDescriptorSets(write, {});
+    allocateDepthMappingResources(logicalDevice, physicalDevice, descriptorPool, 2048, false);
 }
 
 } // namespace sauce

--- a/src/app/components/SpotLightComponent.cpp
+++ b/src/app/components/SpotLightComponent.cpp
@@ -1,6 +1,9 @@
 #include "app/components/SpotLightComponent.hpp"
+#include "app/ImageUtils.hpp"
 
 namespace sauce {
+
+std::unique_ptr<vk::raii::DescriptorSetLayout> SpotLightComponent::descriptorSetLayout = nullptr;
 
 SpotLightComponent::SpotLightComponent()
     : LightComponent(LightType::Spot, "SpotLightComponent") {}
@@ -41,6 +44,104 @@ GPULight SpotLightComponent::toGPULight(const glm::vec3& worldPosition) const {
     gpu.innerConeAngle = innerConeAngle;
     gpu.outerConeAngle = outerConeAngle;
     return gpu;
+}
+
+void SpotLightComponent::initDescriptorSetLayout(const sauce::LogicalDevice& logicalDevice) {
+    if (descriptorSetLayout) return;
+
+    vk::DescriptorSetLayoutBinding shadowBinding {
+        .binding = 0,
+        .descriptorType = vk::DescriptorType::eCombinedImageSampler,
+        .descriptorCount = 1,
+        .stageFlags = vk::ShaderStageFlagBits::eFragment
+    };
+
+    vk::DescriptorSetLayoutCreateInfo layoutInfo {
+        .bindingCount = 1,
+        .pBindings = &shadowBinding,
+    };
+    descriptorSetLayout = std::make_unique<vk::raii::DescriptorSetLayout>(*logicalDevice, layoutInfo);
+}
+
+const vk::raii::DescriptorSetLayout& SpotLightComponent::getDescriptorSetLayout() {
+    return *descriptorSetLayout;
+}
+
+void SpotLightComponent::cleanup() {
+    descriptorSetLayout.reset();
+}
+
+void SpotLightComponent::initDepthMappingResources(
+    const sauce::LogicalDevice& logicalDevice,
+    const sauce::PhysicalDevice& physicalDevice,
+    const vk::raii::CommandPool& commandPool,
+    const vk::raii::Queue& queue,
+    const vk::raii::DescriptorPool& descriptorPool,
+    const vk::raii::DescriptorSetLayout& layout)
+{
+    if (depthImage) return;
+
+    uint32_t width = 2048;
+    uint32_t height = 2048;
+
+    depthImage = std::make_unique<vk::raii::Image>(nullptr);
+    depthImageMemory = std::make_unique<vk::raii::DeviceMemory>(nullptr);
+
+    vk::Format depthFormat = vk::Format::eD32Sfloat;
+
+    sauce::ImageUtils::createImage(
+        physicalDevice, logicalDevice,
+        width, height, depthFormat,
+        vk::ImageTiling::eOptimal,
+        vk::ImageUsageFlagBits::eDepthStencilAttachment | vk::ImageUsageFlagBits::eSampled,
+        vk::MemoryPropertyFlagBits::eDeviceLocal,
+        *depthImage, *depthImageMemory
+    );
+
+    depthImageView = std::make_unique<vk::raii::ImageView>(
+        sauce::ImageUtils::createImageView(
+            logicalDevice, *depthImage, depthFormat,
+            vk::ImageAspectFlagBits::eDepth
+        )
+    );
+
+    vk::SamplerCreateInfo samplerInfo{};
+    samplerInfo.magFilter = vk::Filter::eLinear;
+    samplerInfo.minFilter = vk::Filter::eLinear;
+    samplerInfo.mipmapMode = vk::SamplerMipmapMode::eLinear;
+    samplerInfo.addressModeU = vk::SamplerAddressMode::eClampToEdge;
+    samplerInfo.addressModeV = vk::SamplerAddressMode::eClampToEdge;
+    samplerInfo.addressModeW = vk::SamplerAddressMode::eClampToEdge;
+    samplerInfo.compareEnable = VK_TRUE;
+    samplerInfo.compareOp = vk::CompareOp::eLessOrEqual;
+    samplerInfo.borderColor = vk::BorderColor::eFloatOpaqueWhite;
+
+    depthSampler = std::make_unique<vk::raii::Sampler>(*logicalDevice, samplerInfo);
+
+    vk::DescriptorSetAllocateInfo allocInfo {
+        .descriptorPool = *descriptorPool,
+        .descriptorSetCount = 1,
+        .pSetLayouts = &*layout,
+    };
+
+    auto sets = logicalDevice->allocateDescriptorSets(allocInfo);
+    depthDescriptorSet = std::make_unique<vk::raii::DescriptorSet>(std::move(sets[0]));
+
+    vk::DescriptorImageInfo imageInfo {
+        .sampler = **depthSampler,
+        .imageView = **depthImageView,
+        .imageLayout = vk::ImageLayout::eDepthStencilReadOnlyOptimal
+    };
+
+    vk::WriteDescriptorSet write {
+        .dstSet = **depthDescriptorSet,
+        .dstBinding = 0,
+        .descriptorCount = 1,
+        .descriptorType = vk::DescriptorType::eCombinedImageSampler,
+        .pImageInfo = &imageInfo
+    };
+
+    logicalDevice->updateDescriptorSets(write, {});
 }
 
 } // namespace sauce


### PR DESCRIPTION
- DirectionalLightComponent, PointLightComponent, and SpotLightComponent now have a DescriptorSetLayout attribute for descriptor sets. (code is very redundant ik)
- Added depthImage, depthImageMemory, depthImageView, depthSampler, and depthDescriptorSet as members to DirectionalLightComponent, PointLightComponent, and SpotLightComponent.
- DirectionalLightComponent, PointLightComponent, and SpotLightComponent now also have new methods: initDescriptorSetLayout(), getDescriptorSetLayout(), cleanup(), and initDepthMappingResources() for managing their descriptor set states. 
- Created a new method uploadLightGPUResources() in SauceEngineApp. This method iterates through all the entities in the scene that have any of the light components and calls their initDepthMappingResources() method.